### PR TITLE
Remove hero image from help instructions

### DIFF
--- a/docs/help.html
+++ b/docs/help.html
@@ -18,8 +18,6 @@
     .subtle { color: #4b5563; font-size: 14px; margin-bottom: 12px; }
     .emoji { font-size: 20px; }
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; }
-    .hero-figure { margin: 10px 0 14px; display: flex; justify-content: center; }
-    .hero-figure img { width: 100%; max-width: 920px; border-radius: 14px; border: 1px solid #d5ddf2; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08); background: linear-gradient(135deg, #f1f5f9, #e0e7ff); }
     @media (max-width: 640px) { body { padding: 10px; } h1 { font-size: 20px; } .section { padding: 10px; } }
   </style>
 </head>
@@ -38,9 +36,6 @@
       <li>«Когда будет готово?» — ответ зависит от фазы луны и настроения станка</li>
     </ul>
     <p>Мы делаем систему, чтобы эти вопросы больше не звучали, а производственный процесс перестал быть квестом с элементами мистики.</p>
-    <div class="hero-figure">
-      <img src="funny-intro-small.svg" alt="ТСЗП превращает хаос в понятный процесс" loading="lazy" />
-    </div>
     <p><strong>Наши цели простые и понятные:</strong></p>
     <ul>
       <li>все карты — на виду</li>


### PR DESCRIPTION
## Summary
- remove the hero illustration block from the help instructions
- drop related styling now that the image is gone

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938a0804cf083309a1753f896fc86ae)