### PR TITLE
Improve directory editing and tracker search

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,7 +550,8 @@
                 <input id="center-desc" />
               </div>
               <div class="flex-col" style="flex:0 0 auto; align-self:flex-end;">
-                <button type="submit" class="btn-primary">Добавить участок</button>
+                <button type="submit" class="btn-primary" id="center-submit">Добавить участок</button>
+                <button type="button" class="btn-secondary hidden" id="center-cancel-edit">Отмена</button>
               </div>
             </form>
             <div id="centers-table-wrapper" class="table-wrapper"></div>
@@ -572,7 +573,8 @@
                 <input id="op-time" type="number" min="1" value="30" />
               </div>
               <div class="flex-col" style="flex:0 0 auto; align-self:flex-end;">
-                <button type="submit" class="btn-primary">Добавить операцию</button>
+                <button type="submit" class="btn-primary" id="op-submit">Добавить операцию</button>
+                <button type="button" class="btn-secondary hidden" id="op-cancel-edit">Отмена</button>
               </div>
             </form>
             <div id="ops-table-wrapper" class="table-wrapper"></div>

--- a/style.css
+++ b/style.css
@@ -1859,6 +1859,11 @@ footer {
   transform: scale(1.05);
 }
 
+.center-highlight {
+  background: #ecfdf3;
+  border-left: 3px solid #22c55e;
+}
+
 .user-panel {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add edit/cancel controls for operations and centers with data update hooks
- sync item lists from the first operation across subsequent steps when using item mode
- extend tracker search to match center names, highlight matching operations, and limit grouped results to relevant cards

## Testing
- node --check app.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ade3e89a08330b61cd07d627c5fda)