### PR TITLE
Add IMDX import for route card creation

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,7 @@ let activeCardIsNew = false;
 let cardsSearchTerm = '';
 let attachmentContext = null;
 let routeQtyManual = false;
+let imdxImportState = { parsed: null, missing: null };
 const ATTACH_ACCEPT = '.pdf,.doc,.docx,.jpg,.jpeg,.png,.zip,.rar,.7z';
 const ATTACH_MAX_SIZE = 15 * 1024 * 1024; // 15 MB
 let logContextCardId = null;
@@ -1330,6 +1331,285 @@ function ensureOperationCodes() {
   });
 }
 
+// === ИМПОРТ IMDX (ИЗОЛИРОВАННЫЙ) ===
+function resetImdxImportState() {
+  imdxImportState = { parsed: null, missing: null };
+}
+
+function stripUtf8Bom(text) {
+  if (typeof text !== 'string') return '';
+  return text.replace(/^\uFEFF/, '');
+}
+
+function findFirstValueByNames(root, names = []) {
+  if (!root) return '';
+  const lookup = (names || []).map(n => (n || '').toLowerCase());
+  if (!lookup.length) return '';
+  const elements = Array.from(root.getElementsByTagName('*'));
+  for (const el of elements) {
+    const local = (el.localName || '').toLowerCase();
+    if (lookup.includes(local)) {
+      const val = (el.textContent || '').trim();
+      if (val) return val;
+    }
+    for (const attr of Array.from(el.attributes || [])) {
+      const name = (attr.name || '').toLowerCase();
+      if (lookup.includes(name)) {
+        const val = (attr.value || '').trim();
+        if (val) return val;
+      }
+    }
+  }
+  return '';
+}
+
+function parseImdxContent(xmlText) {
+  const parser = new DOMParser();
+  const cleaned = stripUtf8Bom(xmlText || '');
+  const doc = parser.parseFromString(cleaned, 'application/xml');
+  if (!doc || doc.getElementsByTagName('parsererror').length) {
+    throw new Error('Файл IMDX не удалось разобрать');
+  }
+
+  const cardData = {
+    documentDesignation: findFirstValueByNames(doc, ['documentdesignation', 'docdesignation', 'designation']),
+    itemName: findFirstValueByNames(doc, ['itemname', 'productname', 'name']),
+    itemDesignation: findFirstValueByNames(doc, ['itemdesignation', 'drawing', 'drawingnumber'])
+  };
+
+  const operations = [];
+  const allElements = Array.from(doc.getElementsByTagName('*'));
+  const opNodes = allElements.filter(el => {
+    const local = (el.localName || '').toLowerCase();
+    if (['operation', 'routeoperation', 'techoperation', 'op'].includes(local)) return true;
+    const childNames = Array.from(el.children || []).map(c => (c.localName || '').toLowerCase());
+    return childNames.some(n => ['operationcode', 'opcode', 'operationname', 'opname', 'workcenter', 'centername', 'order', 'sequence']
+      .includes(n));
+  });
+
+  const uniqueNodes = Array.from(new Set(opNodes));
+  uniqueNodes.forEach(node => {
+    const opName = findFirstValueByNames(node, ['opname', 'operationname', 'name']);
+    const opCode = findFirstValueByNames(node, ['opcode', 'operationcode', 'code']);
+    const centerName = findFirstValueByNames(node, ['centername', 'workcenter', 'department']);
+    const orderRaw = findFirstValueByNames(node, ['order', 'sequence', 'position']);
+    const order = orderRaw && !Number.isNaN(parseInt(orderRaw, 10))
+      ? parseInt(orderRaw, 10)
+      : null;
+    if (opName || opCode || centerName) {
+      operations.push({ opName, opCode, centerName, order });
+    }
+  });
+
+  if (!cardData.documentDesignation && !cardData.itemName && !cardData.itemDesignation && !operations.length) {
+    throw new Error('В IMDX не найдены данные для импорта');
+  }
+
+  return { card: cardData, operations };
+}
+
+function findCenterByName(name) {
+  if (!name) return null;
+  const target = name.trim().toLowerCase();
+  if (!target) return null;
+  return centers.find(c => (c.name || '').trim().toLowerCase() === target) || null;
+}
+
+function findOpByCodeOrName(opCode, opName) {
+  const code = (opCode || '').trim().toLowerCase();
+  if (code) {
+    const byCode = ops.find(o => (o.code || o.opCode || '').trim().toLowerCase() === code);
+    if (byCode) return byCode;
+  }
+  const name = (opName || '').trim().toLowerCase();
+  if (name) {
+    const byName = ops.find(o => (o.name || '').trim().toLowerCase() === name);
+    if (byName) return byName;
+  }
+  return null;
+}
+
+function collectImdxMissing(parsed) {
+  const missingCenters = new Set();
+  const missingOps = [];
+  if (!parsed || !Array.isArray(parsed.operations)) {
+    return { centers: [], ops: [] };
+  }
+
+  parsed.operations.forEach(op => {
+    const centerName = (op.centerName || '').trim();
+    if (centerName && !findCenterByName(centerName)) {
+      missingCenters.add(centerName);
+    }
+
+    const opRef = findOpByCodeOrName(op.opCode, op.opName);
+    if (!opRef) {
+      const exists = missingOps.some(item => {
+        const sameCode = item.opCode && op.opCode && item.opCode.trim().toLowerCase() === op.opCode.trim().toLowerCase();
+        const sameName = item.opName && op.opName && item.opName.trim().toLowerCase() === op.opName.trim().toLowerCase();
+        return sameCode || sameName;
+      });
+      if (!exists) {
+        missingOps.push({ opCode: op.opCode || '', opName: op.opName || '' });
+      }
+    }
+  });
+
+  return { centers: Array.from(missingCenters), ops: missingOps };
+}
+
+function openImdxImportModal() {
+  const modal = document.getElementById('imdx-import-modal');
+  if (!modal) return;
+  const input = document.getElementById('imdx-file-input');
+  if (input) input.value = '';
+  closeImdxMissingModal();
+  modal.classList.remove('hidden');
+}
+
+function closeImdxImportModal() {
+  const modal = document.getElementById('imdx-import-modal');
+  if (!modal) return;
+  modal.classList.add('hidden');
+}
+
+function renderImdxMissingList(listEl, items = []) {
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  items.forEach(text => {
+    const li = document.createElement('li');
+    li.textContent = text;
+    listEl.appendChild(li);
+  });
+}
+
+function openImdxMissingModal(missing) {
+  const modal = document.getElementById('imdx-missing-modal');
+  if (!modal) return;
+  const centersList = document.getElementById('imdx-missing-centers');
+  const opsList = document.getElementById('imdx-missing-ops');
+  renderImdxMissingList(centersList, (missing && missing.centers) || []);
+  renderImdxMissingList(opsList, (missing && missing.ops ? missing.ops.map(op => op.opName || op.opCode || 'Операция') : []));
+  modal.classList.remove('hidden');
+}
+
+function closeImdxMissingModal() {
+  const modal = document.getElementById('imdx-missing-modal');
+  if (!modal) return;
+  modal.classList.add('hidden');
+}
+
+async function handleImdxImportConfirm() {
+  if (!activeCardDraft) return;
+  const input = document.getElementById('imdx-file-input');
+  const file = input && input.files ? input.files[0] : null;
+  if (!file) {
+    alert('Выберите файл IMDX');
+    return;
+  }
+  try {
+    const text = await file.text();
+    const parsed = parseImdxContent(text);
+    const missing = collectImdxMissing(parsed);
+    imdxImportState = { parsed, missing };
+    closeImdxImportModal();
+    if ((missing.centers && missing.centers.length) || (missing.ops && missing.ops.length)) {
+      openImdxMissingModal(missing);
+      return;
+    }
+    applyImdxImport(parsed);
+    resetImdxImportState();
+  } catch (err) {
+    alert('Ошибка импорта IMDX: ' + err.message);
+  }
+}
+
+async function confirmImdxMissingAdd() {
+  const state = imdxImportState || {};
+  if (!state.parsed || !state.missing) {
+    closeImdxMissingModal();
+    resetImdxImportState();
+    return;
+  }
+
+  const usedCodes = collectUsedOpCodes();
+  (state.missing.centers || []).forEach(name => {
+    const trimmed = (name || '').trim();
+    if (!trimmed || findCenterByName(trimmed)) return;
+    centers.push({ id: genId('wc'), name: trimmed, desc: '' });
+  });
+
+  (state.missing.ops || []).forEach(op => {
+    const name = (op.opName || '').trim();
+    const code = (op.opCode || '').trim();
+    if (findOpByCodeOrName(code, name)) return;
+    let finalCode = code;
+    if (!finalCode || usedCodes.has(finalCode)) {
+      finalCode = generateUniqueOpCode(usedCodes);
+    }
+    usedCodes.add(finalCode);
+    ops.push({ id: genId('op'), code: finalCode, name: name || finalCode, desc: '', recTime: 30 });
+  });
+
+  await saveData();
+  closeImdxMissingModal();
+  applyImdxImport(state.parsed);
+  resetImdxImportState();
+}
+
+function applyImdxImport(parsed) {
+  if (!activeCardDraft || !parsed) return;
+  const { card = {}, operations = [] } = parsed;
+  const setFieldIfEmpty = (field, value, inputId) => {
+    const val = (value || '').trim();
+    if (!val) return;
+    const current = (activeCardDraft[field] || '').trim();
+    if (current) return;
+    activeCardDraft[field] = val;
+    if (inputId) {
+      const input = document.getElementById(inputId);
+      if (input && !input.value.trim()) {
+        input.value = val;
+      }
+    }
+  };
+
+  setFieldIfEmpty('documentDesignation', card.documentDesignation, 'card-document-designation');
+  setFieldIfEmpty('itemDesignation', card.itemDesignation, 'card-item-designation');
+  const itemName = (card.itemName || '').trim();
+  if (itemName && !(activeCardDraft.itemName || '').trim()) {
+    activeCardDraft.itemName = itemName;
+    activeCardDraft.name = itemName;
+    const nameInput = document.getElementById('card-name');
+    if (nameInput && !nameInput.value.trim()) {
+      nameInput.value = itemName;
+    }
+  }
+
+  activeCardDraft.operations = [];
+  const sortedOps = (operations || []).map((op, idx) => ({ ...op, __idx: idx })).sort((a, b) => {
+    const aOrder = Number.isFinite(a.order) ? a.order : a.__idx + 1;
+    const bOrder = Number.isFinite(b.order) ? b.order : b.__idx + 1;
+    return aOrder - bOrder;
+  });
+  sortedOps.forEach((op, idx) => {
+    const center = findCenterByName(op.centerName);
+    const opRef = findOpByCodeOrName(op.opCode, op.opName);
+    if (!center || !opRef) return;
+    const orderVal = Number.isFinite(op.order) ? op.order : ((op.order != null && !Number.isNaN(parseInt(op.order, 10))) ? parseInt(op.order, 10) : idx + 1);
+    const rop = createRouteOpFromRefs(opRef, center, '', 0, orderVal, { autoCode: true });
+    activeCardDraft.operations.push(rop);
+  });
+
+  updateCardMainSummary();
+  renderRouteTableDraft();
+  fillRouteSelectors();
+  const statusEl = document.getElementById('card-status-text');
+  if (statusEl) {
+    statusEl.textContent = cardStatusText(activeCardDraft);
+  }
+}
+
 // === ХРАНИЛИЩЕ ===
 async function saveData() {
   try {
@@ -2431,6 +2711,9 @@ function setupCardSectionMenu() {
 function openCardModal(cardId) {
   const modal = document.getElementById('card-modal');
   if (!modal) return;
+  closeImdxImportModal();
+  closeImdxMissingModal();
+  resetImdxImportState();
   focusCardsSection();
   activeCardOriginalId = cardId || null;
   if (cardId) {
@@ -2506,6 +2789,9 @@ function closeCardModal() {
   document.getElementById('route-form').reset();
   document.getElementById('route-table-wrapper').innerHTML = '';
   setCardMainCollapsed(false);
+  closeImdxImportModal();
+  closeImdxMissingModal();
+  resetImdxImportState();
   activeCardDraft = null;
   activeCardOriginalId = null;
   activeCardIsNew = false;
@@ -6359,6 +6645,40 @@ function setupForms() {
         }
       }
       renderRouteTableDraft();
+    });
+  }
+
+  const importImdxBtn = document.getElementById('card-import-imdx-btn');
+  if (importImdxBtn) {
+    importImdxBtn.addEventListener('click', () => {
+      if (!activeCardDraft) return;
+      openImdxImportModal();
+    });
+  }
+
+  const imdxImportConfirm = document.getElementById('imdx-import-confirm');
+  if (imdxImportConfirm) {
+    imdxImportConfirm.addEventListener('click', () => handleImdxImportConfirm());
+  }
+
+  const imdxImportCancel = document.getElementById('imdx-import-cancel');
+  if (imdxImportCancel) {
+    imdxImportCancel.addEventListener('click', () => {
+      closeImdxImportModal();
+      resetImdxImportState();
+    });
+  }
+
+  const imdxMissingConfirm = document.getElementById('imdx-missing-confirm');
+  if (imdxMissingConfirm) {
+    imdxMissingConfirm.addEventListener('click', () => confirmImdxMissingAdd());
+  }
+
+  const imdxMissingCancel = document.getElementById('imdx-missing-cancel');
+  if (imdxMissingCancel) {
+    imdxMissingCancel.addEventListener('click', () => {
+      closeImdxMissingModal();
+      resetImdxImportState();
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -498,6 +498,7 @@
             <button type="button" id="card-create-group-btn" class="btn-secondary">Создать группу карт</button>
           </div>
           <div class="modal-actions-right">
+            <button type="button" id="card-import-imdx-btn" class="btn-secondary">Импорт (IMDX)</button>
             <button type="button" id="card-save-btn" class="btn-primary">Сохранить карту</button>
             <button type="button" id="card-print-btn" class="btn-secondary">Печать</button>
             <button type="button" id="card-cancel-btn" class="btn-secondary">Закрыть</button>
@@ -549,6 +550,48 @@
       <div class="modal-actions">
         <button type="button" id="group-create-confirm" class="btn-primary">Создать группу</button>
         <button type="button" id="group-create-cancel" class="btn-secondary">Отмена</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="imdx-import-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="imdx-import-title">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 id="imdx-import-title">Импорт IMDX</h3>
+      </div>
+      <div class="modal-body">
+        <div class="flex-col" style="gap: 8px;">
+          <label for="imdx-file-input">Выберите файл .imdx для импорта маршрутной карты</label>
+          <input type="file" id="imdx-file-input" accept=".imdx" />
+        </div>
+      </div>
+      <div class="modal-actions">
+        <button type="button" id="imdx-import-confirm" class="btn-primary">Добавить</button>
+        <button type="button" id="imdx-import-cancel" class="btn-secondary">Отмена</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="imdx-missing-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="imdx-missing-title">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 id="imdx-missing-title">Не найдены в справочниках</h3>
+      </div>
+      <div class="modal-body">
+        <div class="flex-col" style="gap: 16px;">
+          <div class="flex-col">
+            <h4>Подразделения</h4>
+            <ul id="imdx-missing-centers" class="imdx-missing-list"></ul>
+          </div>
+          <div class="flex-col">
+            <h4>Операции</h4>
+            <ul id="imdx-missing-ops" class="imdx-missing-list"></ul>
+          </div>
+        </div>
+      </div>
+      <div class="modal-actions">
+        <button type="button" id="imdx-missing-confirm" class="btn-primary">Добавить</button>
+        <button type="button" id="imdx-missing-cancel" class="btn-secondary">Отмена</button>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -2906,3 +2906,16 @@ footer {
 @media (min-width: 769px) {
   #mobile-operations-view { display: none !important; }
 }
+
+.imdx-missing-list {
+  margin: 6px 0 0 20px;
+  padding: 0;
+  list-style: disc;
+}
+
+.imdx-missing-list:empty::before {
+  content: 'Все элементы найдены';
+  color: #666;
+  list-style: none;
+  margin-left: -20px;
+}


### PR DESCRIPTION
## Summary
- add an isolated IMDX import entry point in the route card creation modal with new dialogs
- parse IMDX files on the client, validate directory references, and allow optional addition of missing centers/operations
- populate the active card draft and operations from IMDX without altering existing flows or auto-saving

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ef5421e948330a7747b54664d2c2e)