### PR TITLE
Fix barcode print triggering and add manual fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -1046,6 +1046,35 @@ function closeBarcodeModal(silent = false) {
   }
 }
 
+function openPrintWindow(url) {
+  const win = window.open(url, '_blank');
+  if (!win) return;
+
+  try {
+    win.focus();
+  } catch (e) {}
+
+  const trigger = () => {
+    try {
+      win.focus();
+    } catch (e) {}
+    try {
+      win.print();
+    } catch (e) {}
+    setTimeout(() => {
+      try {
+        win.print();
+      } catch (e) {}
+    }, 350);
+  };
+
+  try {
+    win.addEventListener('load', trigger, { once: true });
+  } catch (e) {
+    setTimeout(trigger, 300);
+  }
+}
+
 function setupBarcodeModal() {
   const modal = document.getElementById('barcode-modal');
   if (!modal) return;
@@ -1057,13 +1086,13 @@ function setupBarcodeModal() {
   }
 
   if (printBtn) {
-    printBtn.addEventListener('click', async () => {
+    printBtn.addEventListener('click', () => {
       const mode = modal.dataset.mode || 'card';
       if (mode === 'password') {
         const userId = (modal.dataset.userId || '').trim();
         if (userId) {
           const url = '/print/barcode/password/' + encodeURIComponent(userId);
-          await openPrintPreview(url);
+          openPrintWindow(url);
         }
         return;
       }
@@ -1071,14 +1100,14 @@ function setupBarcodeModal() {
       const groupId = (modal.dataset.groupId || '').trim();
       if (groupId) {
         const url = '/print/barcode/group/' + encodeURIComponent(groupId);
-        await openPrintPreview(url);
+        openPrintWindow(url);
         return;
       }
 
       const cardId = (modal.dataset.cardId || '').trim();
       if (cardId) {
         const url = '/print/barcode/mk/' + encodeURIComponent(cardId);
-        await openPrintPreview(url);
+        openPrintWindow(url);
       }
     });
   }

--- a/templates/print/barcode-group.ejs
+++ b/templates/print/barcode-group.ejs
@@ -8,9 +8,12 @@
     .barcode-wrapper { display: inline-flex; flex-direction: column; align-items: center; gap: 12px; }
     #barcode { width: 100%; max-width: 420px; }
     .code-text { font-size: 16px; font-weight: 600; }
+    .print-btn { padding: 10px 14px; margin-bottom: 16px; font-size: 14px; cursor: pointer; }
+    @media print { .print-btn { display: none; } }
   </style>
 </head>
 <body>
+  <button class="print-btn" onclick="window.print()">Печать</button>
   <div class="barcode-wrapper">
     <svg id="barcode"></svg>
     <div class="code-text">Группа: <%= card && card.name ? escapeHtml(card.name) : '' %></div>
@@ -28,7 +31,11 @@
           console.error('Barcode render error', err);
         }
       }
-      setTimeout(function() { window.print(); }, 100);
+      if (window.requestAnimationFrame) {
+        requestAnimationFrame(() => window.print());
+      } else {
+        window.print();
+      }
     });
   </script>
 </body>

--- a/templates/print/barcode-mk.ejs
+++ b/templates/print/barcode-mk.ejs
@@ -8,9 +8,12 @@
     .barcode-wrapper { display: inline-flex; flex-direction: column; align-items: center; gap: 12px; }
     #barcode { width: 100%; max-width: 420px; }
     .code-text { font-size: 16px; font-weight: 600; }
+    .print-btn { padding: 10px 14px; margin-bottom: 16px; font-size: 14px; cursor: pointer; }
+    @media print { .print-btn { display: none; } }
   </style>
 </head>
 <body>
+  <button class="print-btn" onclick="window.print()">Печать</button>
   <div class="barcode-wrapper">
     <svg id="barcode"></svg>
     <div class="code-text">Код МК: <%= code || '(нет штрихкода)' %></div>
@@ -30,7 +33,11 @@
           console.error('Barcode render error', err);
         }
       }
-      setTimeout(function() { window.print(); }, 100);
+      if (window.requestAnimationFrame) {
+        requestAnimationFrame(() => window.print());
+      } else {
+        window.print();
+      }
     });
   </script>
 </body>

--- a/templates/print/barcode-password.ejs
+++ b/templates/print/barcode-password.ejs
@@ -9,9 +9,12 @@
     #barcode { width: 100%; max-width: 420px; }
     .code-text { font-size: 16px; font-weight: 600; }
     .username { font-size: 14px; color: #374151; }
+    .print-btn { padding: 10px 14px; margin-bottom: 16px; font-size: 14px; cursor: pointer; }
+    @media print { .print-btn { display: none; } }
   </style>
 </head>
 <body>
+  <button class="print-btn" onclick="window.print()">Печать</button>
   <div class="barcode-wrapper">
     <svg id="barcode"></svg>
     <% if (username) { %>
@@ -31,7 +34,11 @@
           console.error('Barcode render error', err);
         }
       }
-      setTimeout(function() { window.print(); }, 100);
+      if (window.requestAnimationFrame) {
+        requestAnimationFrame(() => window.print());
+      } else {
+        window.print();
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- open barcode print previews with load-aware print triggering and a retry to encourage system dialogs
- add explicit Print buttons to barcode print templates as a fallback when auto-print is blocked
- use immediate print invocation without extra delays while preserving Code128 rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694194098a988328bc5f89d750563a88)