### PR TITLE
Use server-side Code128 SVGs for print

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,14 +17,20 @@ const BARCODE_GROUP_TEMPLATE = path.join(TEMPLATE_DIR, 'print', 'barcode-group.e
 const BARCODE_PASSWORD_TEMPLATE = path.join(TEMPLATE_DIR, 'print', 'barcode-password.ejs');
 const LOG_SUMMARY_TEMPLATE = path.join(TEMPLATE_DIR, 'print', 'log-summary.ejs');
 const LOG_FULL_TEMPLATE = path.join(TEMPLATE_DIR, 'print', 'log-full.ejs');
-const CODE128_VENDOR_PATH = path.join(__dirname, 'vendor', 'code128.js');
-let CODE128_VENDOR_SOURCE = '';
-function getCode128VendorSource() {
-  if (!CODE128_VENDOR_SOURCE) {
-    CODE128_VENDOR_SOURCE = fs.readFileSync(CODE128_VENDOR_PATH, 'utf8');
-  }
-  return CODE128_VENDOR_SOURCE;
-}
+const CODE128_PATTERNS = [
+  '11011001100', '11001101100', '11001100110', '10010011000', '10010001100', '10001001100', '10011001000', '10011000100', '10001100100',
+  '11001001000', '11001000100', '11000100100', '10110011100', '10011011100', '10011001110', '10111001100', '10011101100', '10011100110',
+  '11001110010', '11001011100', '11001001110', '11011100100', '11001110100', '11101101110', '11101001100', '11100101100', '11100100110',
+  '11101100100', '11100110100', '11100110010', '11011011000', '11011000110', '11000110110', '10100011000', '10001011000', '10001000110',
+  '10110001000', '10001101000', '10001100010', '11010001000', '11000101000', '11000100010', '10110111000', '10110001110', '10001101110',
+  '10111011000', '10111000110', '10001110110', '11101110110', '11010001110', '11000101110', '11011101000', '11011100010', '11011101110',
+  '11101011000', '11101000110', '11100010110', '11101101000', '11101100010', '11100011010', '11101111010', '11001000010', '11110001010',
+  '10100110000', '10100001100', '10010110000', '10010000110', '10000101100', '10000100110', '10110010000', '10110000100', '10011010000',
+  '10011000010', '10000110100', '10000110010', '11000010010', '11001010000', '11110111010', '11000010100', '10001111010', '10100111100',
+  '10010111100', '10010011110', '10111100100', '10011110100', '10011110010', '11110100100', '11110010100', '11110010010', '11011011110',
+  '11011110110', '11110110110', '10101111000', '10100011110', '10001011110', '10111101000', '10111100010', '11110101000', '11110100010',
+  '10111011110', '10111101110', '11101011110', '11110101110', '11010000100', '11010010000', '11010011100', '1100011101011'
+];
 const MAX_BODY_SIZE = 20 * 1024 * 1024; // 20 MB to allow attachments
 const FILE_SIZE_LIMIT = 15 * 1024 * 1024; // 15 MB per attachment
 const ALLOWED_EXTENSIONS = ['.pdf', '.doc', '.docx', '.jpg', '.jpeg', '.png', '.zip', '.rar', '.7z'];
@@ -65,6 +71,57 @@ function trimToString(value) {
   if (value == null) return '';
   const str = typeof value === 'string' ? value : String(value);
   return str.trim();
+}
+
+function escapeForSvgText(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function generateCode128Svg(value, options = {}) {
+  const text = value == null ? '' : String(value);
+  const codes = [104];
+  for (let i = 0; i < text.length; i++) {
+    const mapped = Math.max(0, Math.min(95, text.charCodeAt(i) - 32));
+    codes.push(mapped);
+  }
+
+  let checksum = 104;
+  for (let i = 0; i < codes.length; i++) {
+    checksum += codes[i] * (i === 0 ? 1 : i);
+  }
+  codes.push(checksum % 103);
+  codes.push(106);
+
+  const bits = codes.map(code => CODE128_PATTERNS[code] || '').join('');
+  const barWidth = Number.isFinite(Number(options.barWidth)) ? Number(options.barWidth) : 2;
+  const barHeight = Number.isFinite(Number(options.height)) ? Number(options.height) : 80;
+  const margin = Number.isFinite(Number(options.margin)) ? Number(options.margin) : 10;
+  const displayValue = options.displayValue !== false;
+  const label = options.label != null ? String(options.label) : text;
+  const width = bits.length * barWidth + margin * 2;
+  const height = barHeight + (displayValue ? 18 : 0) + margin * 2;
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${escapeForSvgText(label)}">`;
+  svg += `<g transform="translate(${margin},${margin})">`;
+  for (let i = 0; i < bits.length; i++) {
+    if (bits[i] === '1') {
+      const x = i * barWidth;
+      svg += `<rect x="${x}" y="0" width="${barWidth}" height="${barHeight}" fill="#000"/>`;
+    }
+  }
+  svg += '</g>';
+
+  if (displayValue) {
+    svg += `<text x="${margin}" y="${barHeight + margin + 12}" font-size="12" font-family="system-ui, -apple-system, &quot;Segoe UI&quot;, sans-serif">${escapeForSvgText(label)}</text>`;
+  }
+
+  svg += '</svg>';
+  return svg;
 }
 
 function formatDateStamp(date = new Date()) {
@@ -1252,7 +1309,8 @@ async function handlePrintRoutes(req, res) {
         mk: mapCardForPrint(card),
         operations: mapOperationsForPrint(card),
         routeCardNumber: card.routeCardNumber || '',
-        barcodeValue: trimToString(card.routeCardNumber || '')
+        barcodeValue: trimToString(card.routeCardNumber || ''),
+        barcodeSvg: generateCode128Svg(card.routeCardNumber || '', { displayValue: false, margin: 0, height: 60 })
       });
       res.writeHead(200, {
         'Content-Type': 'text/html; charset=utf-8',
@@ -1277,7 +1335,7 @@ async function handlePrintRoutes(req, res) {
       const html = renderBarcodeMk({
         code,
         card,
-        code128Source: getCode128VendorSource()
+        barcodeSvg: generateCode128Svg(code, { displayValue: false, margin: 10, height: 80 })
       });
 
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
@@ -1295,7 +1353,11 @@ async function handlePrintRoutes(req, res) {
       }
       await ensureCardBarcode(card);
       const code = trimToString(card.barcode || '');
-      const html = renderBarcodeGroup({ code, card });
+      const html = renderBarcodeGroup({
+        code,
+        card,
+        barcodeSvg: generateCode128Svg(code, { displayValue: false, margin: 10, height: 80 })
+      });
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
       res.end(html);
       return true;
@@ -1312,7 +1374,8 @@ async function handlePrintRoutes(req, res) {
       const password = trimToString(target.password || '');
       const html = renderBarcodePassword({
         code: password,
-        username: trimToString(target.name || '')
+        username: trimToString(target.name || ''),
+        barcodeSvg: generateCode128Svg(password, { displayValue: false, margin: 10, height: 80 })
       });
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
       res.end(html);
@@ -1333,6 +1396,7 @@ async function handlePrintRoutes(req, res) {
       const html = renderLogSummary({
         card,
         barcodeValue,
+        barcodeSvg: generateCode128Svg(barcodeValue, { displayValue: false, margin: 10, height: 80 }),
         summaryHtml: buildSummaryTableHtml(card),
         formatQuantityValue,
         cardStatusText
@@ -1356,6 +1420,7 @@ async function handlePrintRoutes(req, res) {
       const html = renderLogFull({
         card,
         barcodeValue,
+        barcodeSvg: generateCode128Svg(barcodeValue, { displayValue: false, margin: 10, height: 80 }),
         initialHtml: buildInitialSnapshotHtml(card),
         historyHtml: buildLogHistoryTableHtml(card),
         summaryHtml: buildSummaryTableHtml(card, { blankForPrint: false }),

--- a/templates/print/barcode-group.ejs
+++ b/templates/print/barcode-group.ejs
@@ -6,51 +6,15 @@
   <style>
     body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; text-align: center; margin: 24px; }
     .barcode-wrapper { display: inline-flex; flex-direction: column; align-items: center; gap: 12px; }
-    #barcode { width: 100%; max-width: 420px; }
+    .barcode-wrapper svg { width: 100%; max-width: 420px; height: auto; }
     .code-text { font-size: 16px; font-weight: 600; }
   </style>
 </head>
-<body>
+<body onload="window.print()">
   <div class="barcode-wrapper">
-    <svg id="barcode"></svg>
+    <div class="barcode-svg"><%- barcodeSvg %></div>
     <div class="code-text">Группа: <%= card && card.name ? escapeHtml(card.name) : '' %></div>
     <div class="code-text">Код группы: <%= code || '(нет штрихкода группы)' %></div>
   </div>
-
-  <script src="/vendor/code128.js"></script>
-  <script>
-    window.addEventListener('load', function () {
-      var code = <%- JSON.stringify(code) %>;
-      var svg = document.getElementById('barcode');
-
-      if (!code || !svg || !window.Code128 || typeof window.Code128.drawToSvg !== 'function') {
-        console.error('Barcode render prerequisites missing', { code: code, svg: !!svg, Code128: !!window.Code128 });
-        return;
-      }
-
-      try {
-        // 1) Генерим SVG ДО печати
-        window.Code128.drawToSvg(svg, code, { displayValue: false, margin: 10, height: 80 });
-      } catch (err) {
-        console.error('Code128 render error', err);
-        return;
-      }
-
-      // 2) Печатаем ТОЛЬКО 1 раз (чтобы "Отмена" не открывала снова)
-      if (window.__barcodePrinted) return;
-      window.__barcodePrinted = true;
-
-      // небольшая задержка, чтобы браузер успел применить layout/SVG
-      setTimeout(function () {
-        try { window.print(); } catch (e) { console.error('Print error', e); }
-      }, 300);
-
-      // 3) Никаких повторных print. Можно просто закрыть вкладку после диалога
-      window.addEventListener('afterprint', function () {
-        // если вкладка открыта отдельным окном — закрываем
-        try { window.close(); } catch (e) {}
-      });
-    });
-  </script>
 </body>
 </html>

--- a/templates/print/barcode-mk.ejs
+++ b/templates/print/barcode-mk.ejs
@@ -8,72 +8,20 @@
     body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; text-align: center; margin: 0; padding: 0; }
     .wrap { margin-top: 20mm; }
     .barcode-wrapper { display: inline-flex; flex-direction: column; align-items: center; gap: 10px; }
-    #barcode { width: 100%; max-width: 420px; }
+    .barcode-wrapper svg { width: 100%; max-width: 420px; height: auto; }
     .code-text { font-size: 16px; font-weight: 600; }
     .name-text { font-size: 14px; }
   </style>
 </head>
-<body>
+<body onload="window.print()">
   <div class="wrap">
     <div class="barcode-wrapper">
-      <svg id="barcode"></svg>
+      <div class="barcode-svg"><%- barcodeSvg %></div>
       <div class="code-text">Код МК: <%= code || '(нет номера МК)' %></div>
       <% if (card && card.name) { %>
         <div class="name-text"><%= escapeHtml(card.name) %></div>
       <% } %>
     </div>
   </div>
-
-  <!-- ВСТРОЕННЫЙ ГЕНЕРАТОР Code128: никаких /vendor/... запросов -->
-  <script>
-    <%- code128Source %>
-  </script>
-
-  <script>
-    (function () {
-      var code = <%- JSON.stringify(code || '') %>;
-      var svg = document.getElementById('barcode');
-
-      // 1) Генерим SVG гарантированно ДО печати
-      function renderBarcode() {
-        if (!code || !svg || !window.Code128 || typeof window.Code128.drawToSvg !== 'function') {
-          console.error('Code128 prerequisites missing', { code: code, svg: !!svg, Code128: !!window.Code128 });
-          return false;
-        }
-        try {
-          window.Code128.drawToSvg(svg, code, { displayValue: false, margin: 10, height: 80 });
-          return true;
-        } catch (e) {
-          console.error('Code128 render error', e);
-          return false;
-        }
-      }
-
-      // 2) ЖЁСТКАЯ защита от повторной печати (включая случаи "Отмена" и перезагрузки/повторного открытия)
-      var onceKey = 'barcode_printed:' + code;
-      if (sessionStorage.getItem(onceKey) === '1') {
-        // Уже пытались печатать эту страницу — не запускаем print() снова
-        renderBarcode();
-        return;
-      }
-      sessionStorage.setItem(onceKey, '1');
-
-      // 3) Рендер → маленькая задержка → печать
-      window.addEventListener('load', function () {
-        var ok = renderBarcode();
-        if (!ok) return;
-
-        // Дадим браузеру применить layout/SVG
-        setTimeout(function () {
-          try { window.print(); } catch (e) { console.error('Print error', e); }
-        }, 250);
-      });
-
-      // Никаких автопереоткрытий/перезагрузок после afterprint
-      window.addEventListener('afterprint', function () {
-        // ничего не делаем — иначе можно поймать петлю
-      });
-    })();
-  </script>
 </body>
 </html>

--- a/templates/print/barcode-password.ejs
+++ b/templates/print/barcode-password.ejs
@@ -6,54 +6,18 @@
   <style>
     body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; text-align: center; margin: 24px; }
     .barcode-wrapper { display: inline-flex; flex-direction: column; align-items: center; gap: 12px; }
-    #barcode { width: 100%; max-width: 420px; }
+    .barcode-wrapper svg { width: 100%; max-width: 420px; height: auto; }
     .code-text { font-size: 16px; font-weight: 600; }
     .username { font-size: 14px; color: #374151; }
   </style>
 </head>
-<body>
+<body onload="window.print()">
   <div class="barcode-wrapper">
-    <svg id="barcode"></svg>
+    <div class="barcode-svg"><%- barcodeSvg %></div>
     <% if (username) { %>
       <div class="username">Пользователь: <%= escapeHtml(username) %></div>
     <% } %>
     <div class="code-text">Пароль пользователя: <%= code || '(нет пароля)' %></div>
   </div>
-
-  <script src="/vendor/code128.js"></script>
-  <script>
-    window.addEventListener('load', function () {
-      var code = <%- JSON.stringify(code) %>;
-      var svg = document.getElementById('barcode');
-
-      if (!code || !svg || !window.Code128 || typeof window.Code128.drawToSvg !== 'function') {
-        console.error('Barcode render prerequisites missing', { code: code, svg: !!svg, Code128: !!window.Code128 });
-        return;
-      }
-
-      try {
-        // 1) Генерим SVG ДО печати
-        window.Code128.drawToSvg(svg, code, { displayValue: false, margin: 10, height: 80 });
-      } catch (err) {
-        console.error('Code128 render error', err);
-        return;
-      }
-
-      // 2) Печатаем ТОЛЬКО 1 раз (чтобы "Отмена" не открывала снова)
-      if (window.__barcodePrinted) return;
-      window.__barcodePrinted = true;
-
-      // небольшая задержка, чтобы браузер успел применить layout/SVG
-      setTimeout(function () {
-        try { window.print(); } catch (e) { console.error('Print error', e); }
-      }, 300);
-
-      // 3) Никаких повторных print. Можно просто закрыть вкладку после диалога
-      window.addEventListener('afterprint', function () {
-        // если вкладка открыта отдельным окном — закрываем
-        try { window.close(); } catch (e) {}
-      });
-    });
-  </script>
 </body>
 </html>

--- a/templates/print/log-full.ejs
+++ b/templates/print/log-full.ejs
@@ -31,9 +31,10 @@
     .item-name { font-weight: 700; }
     .item-chips { display: flex; flex-wrap: wrap; gap: 6px; }
     .section-spacer { margin-top: 12px; }
+    .barcode-print svg { width: 180px; max-width: 100%; height: auto; }
   </style>
 </head>
-<body>
+<body onload="window.print()">
   <h2><%= escapeHtml(card.name || '') %></h2>
   <div class="meta-print"><strong>Заказ:</strong> <%= escapeHtml(card.orderNo || '') %></div>
   <div class="meta-print"><strong>Количество, шт:</strong> <%= escapeHtml(formatQuantityValue(card.quantity)) %></div>
@@ -42,7 +43,7 @@
   <div class="meta-print"><strong>Статус:</strong> <%= escapeHtml(cardStatusText(card)) %></div>
   <div class="meta-print"><strong>Создана:</strong> <%= escapeHtml(new Date(card.createdAt || Date.now()).toLocaleString()) %></div>
   <div class="barcode-print">
-    <svg id="barcode"></svg>
+    <div class="barcode-svg"><%- barcodeSvg %></div>
     <div class="meta-stack">
       <div class="meta-print"><strong>Код МК:</strong> <%= escapeHtml(barcodeValue || card.routeCardNumber || '') %></div>
     </div>
@@ -50,20 +51,5 @@
   <div class="section-spacer"><h3>Вид карты при создании</h3><%- initialHtml %></div>
   <div class="section-spacer"><h3>История изменений</h3><%- historyHtml %></div>
   <div class="section-spacer"><h3>Сводная таблица операций</h3><%- summaryHtml %></div>
-
-  <script src="/vendor/code128.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      var code = <%- JSON.stringify(barcodeValue) %>;
-      if (code) {
-        try {
-          Code128.drawToSvg('#barcode', code, { displayValue: false, margin: 10, height: 80 });
-        } catch (err) {
-          console.error('Barcode render error', err);
-        }
-      }
-      setTimeout(function() { window.print(); }, 100);
-    });
-  </script>
 </body>
 </html>

--- a/templates/print/log-summary.ejs
+++ b/templates/print/log-summary.ejs
@@ -21,13 +21,14 @@
     .meta-stack { display: flex; flex-direction: column; gap: 2px; }
     .summary-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
     .summary-header .meta-stack { align-items: flex-end; text-align: right; }
+    .barcode-print svg { width: 180px; max-width: 100%; height: auto; }
   </style>
 </head>
-<body>
+<body onload="window.print()">
   <h2><%= escapeHtml(card.name || '') %></h2>
   <div class="summary-header">
     <div class="barcode-print">
-      <svg id="barcode"></svg>
+      <div class="barcode-svg"><%- barcodeSvg %></div>
       <div class="meta-stack">
         <div class="meta-print"><strong>Код МК:</strong> <%= escapeHtml(barcodeValue || card.routeCardNumber || '') %></div>
         <div class="meta-print"><strong>Заказ:</strong> <%= escapeHtml(card.orderNo || '') %></div>
@@ -42,20 +43,5 @@
     </div>
   </div>
   <div><%- summaryHtml %></div>
-
-  <script src="/vendor/code128.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      var code = <%- JSON.stringify(barcodeValue) %>;
-      if (code) {
-        try {
-          Code128.drawToSvg('#barcode', code, { displayValue: false, margin: 10, height: 80 });
-        } catch (err) {
-          console.error('Barcode render error', err);
-        }
-      }
-      setTimeout(function() { window.print(); }, 100);
-    });
-  </script>
 </body>
 </html>

--- a/templates/print/mk-print.ejs
+++ b/templates/print/mk-print.ejs
@@ -14,14 +14,15 @@
     }
     body { margin:0; padding:0; }
     .barcode-text { text-align:center; font-family:'Times New Roman',serif; font-size:12px; letter-spacing:1px; margin-top:4px; }
+    .barcode-svg svg { display:block; width:100%; height:auto; }
   </style>
 </head>
 
-<body>
+<body onload="window.print()">
 
 <!-- Code128 НАД ТАБЛИЦЕЙ (НЕ В ТАБЛИЦЕ) -->
 <div style="margin:0 0 8px 0;">
-  <svg id="mk_barcode" style="display:block;"></svg>
+  <div class="barcode-svg"><%- barcodeSvg %></div>
   <div class="barcode-text"><%= barcodeValue || routeCardNumber %></div>
 </div>
 
@@ -256,21 +257,6 @@
 
   </tbody>
 </table>
-
-  <script src="/vendor/code128.js"></script>
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    var code = <%- JSON.stringify(barcodeValue || routeCardNumber) %>;
-    if (code) {
-      try {
-        Code128.drawToSvg("#mk_barcode", code, { displayValue: false, margin: 0, height: 60 });
-      } catch (err) {
-        console.error('Barcode render error', err);
-      }
-    }
-    setTimeout(function() { window.print(); }, 100);
-  });
-</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a server-side Code128 SVG generator and reuse it for all print routes
- send generated barcode SVGs to every print template instead of client-side rendering
- strip Code128 scripts from print templates and trigger printing once on load

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941b256ec9c83289036de801a9697d1)