### PR TITLE
Add MKI card scaffolding and display helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,11 +132,24 @@
           <div class="cards-toolbar">
             <div class="button-group">
               <button class="btn-primary" id="btn-new-card">Создать МК</button>
+              <button class="btn-primary" id="btn-new-mki">Создать МКИ</button>
               <button class="btn-secondary" id="btn-directory-modal">Операции и подразделения</button>
             </div>
           </div>
           <div id="cards-table-wrapper" class="table-wrapper"></div>
         </div>
+      </div>
+    </section>
+
+    <section id="mkiCreate" class="hidden">
+      <div class="card">
+        <h2>Создание МКИ</h2>
+      </div>
+    </section>
+
+    <section id="mkiEdit" class="hidden">
+      <div class="card">
+        <h2>Редактирование МКИ</h2>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add cardType normalization along with helpers for MKI display titles and route number conflict validation
- update card listings, logs, and attachments to use the shared display title helper
- scaffold UI entries for MKI creation/editing and preserve card types when copying or grouping cards

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69431ea4d64083209a6aea0ad892c839)