### PR TITLE
Add delete confirmation and archive deletion flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,15 @@
       <button class="nav-toggle" id="nav-toggle" aria-label="Открыть меню" aria-expanded="false">☰</button>
       <nav id="primary-nav" class="nav-menu">
         <button class="nav-btn active" data-target="dashboard">Дашборд</button>
-        <button class="nav-btn" data-target="cards">МК</button>
+        <div class="nav-dropdown" id="nav-cards-dropdown">
+          <button class="nav-btn nav-dropdown-toggle" type="button" aria-expanded="false" data-target="cards">МК ▾</button>
+          <div class="nav-dropdown-menu" id="nav-cards-menu" role="menu">
+            <button type="button" class="nav-dropdown-item" data-route="/cards">Просмотр МК</button>
+            <button type="button" class="nav-dropdown-item" data-route="/cards/new">Создать МК</button>
+            <button type="button" class="nav-dropdown-item" data-route="/cards-mki/new">Создать МКИ</button>
+            <button type="button" class="nav-dropdown-item" data-route="/directories">Справочники</button>
+          </div>
+        </div>
         <button class="nav-btn" data-target="workorders">Трекер</button>
         <button class="nav-btn" data-target="archive">Архив</button>
         <button class="nav-btn" data-target="workspace"><span class="nav-btn-multiline">Рабочее<br>место</span></button>
@@ -544,6 +552,23 @@
       </div>
       <div class="modal-actions">
         <button type="button" id="attachments-close" class="btn-secondary">Закрыть</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="delete-confirm-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="delete-confirm-title">
+    <div class="modal-content confirm-modal-content">
+      <div class="modal-header">
+        <h3 id="delete-confirm-title">Подтверждение удаления</h3>
+        <button type="button" class="btn-secondary" id="delete-confirm-close" aria-label="Закрыть окно подтверждения">×</button>
+      </div>
+      <div class="modal-body">
+        <p id="delete-confirm-message"></p>
+        <p id="delete-confirm-hint" class="delete-confirm-hint"></p>
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="btn-secondary" id="delete-confirm-cancel">Отменить</button>
+        <button type="button" class="btn-danger" id="delete-confirm-apply">Удалить</button>
       </div>
     </div>
   </div>

--- a/server.js
+++ b/server.js
@@ -1813,6 +1813,21 @@ async function requestHandler(req, res) {
   if (await handlePrintRoutes(req, res)) return;
   if (await handleApi(req, res)) return;
   if (await handleFileRoutes(req, res)) return;
+  const parsed = url.parse(req.url);
+  const spaRoutes = new Set(['/cards', '/cards/new', '/cards-mki/new', '/directories', '/dashboard', '/workorders', '/archive', '/workspace', '/users', '/accessLevels', '/']);
+  if (spaRoutes.has(parsed.pathname || '')) {
+    const indexPath = path.join(__dirname, 'index.html');
+    fs.readFile(indexPath, (err, data) => {
+      if (err) {
+        res.writeHead(500);
+        res.end('Server error');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(data);
+    });
+    return;
+  }
   serveStatic(req, res);
 }
 

--- a/style.css
+++ b/style.css
@@ -204,6 +204,52 @@ header h1 {
   text-align: center;
 }
 
+.nav-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.nav-dropdown-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.nav-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 8px 0;
+  min-width: 200px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
+  display: none;
+  z-index: 50;
+}
+
+.nav-dropdown-menu.open {
+  display: block;
+}
+
+.nav-dropdown-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 14px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #111827;
+}
+
+.nav-dropdown-item:hover,
+.nav-dropdown-item:focus {
+  background: #f3f4f6;
+}
+
 .status-banner {
   margin: 0;
   padding: 10px 16px;
@@ -1310,6 +1356,23 @@ tbody tr:nth-child(even) {
   padding: 16px 20px;
 }
 
+.modal.page-mode {
+  position: static;
+  inset: auto;
+  background: transparent;
+  display: block;
+  padding: 0;
+  box-shadow: none;
+}
+
+.modal.page-mode .modal-content {
+  max-width: 1200px;
+  width: min(1200px, 100%);
+  max-height: none;
+  box-shadow: none;
+  margin: 0 auto;
+}
+
 .card-modal-content {
   max-width: 1280px;
   width: min(1280px, 98vw);
@@ -1317,6 +1380,17 @@ tbody tr:nth-child(even) {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.confirm-modal-content {
+  max-width: 520px;
+}
+
+.confirm-modal-content .modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .card-modal-content .modal-body {
@@ -1578,6 +1652,12 @@ tbody tr:nth-child(even) {
   margin-top: 12px;
   padding-top: 12px;
   border-top: 1px solid #e5e7eb;
+}
+
+.delete-confirm-hint {
+  margin: 0;
+  font-size: 13px;
+  color: #6b7280;
 }
 
 .card-modal-actions {


### PR DESCRIPTION
## Summary
- convert the “МК” header button into a dropdown that routes to dedicated pages for viewing cards, creating MK/MKI, and directories
- add client-side routing with page-mode versions of the card and directory screens plus server fallbacks for deep links
- keep existing card/directory forms functional while avoiding modal overlays for routed pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6943d8594eac8328908c773fa3ec8aab)