### PR TITLE
Harden modal closing and deduplicate help overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -367,7 +367,7 @@ function closeAllModals(silent = false) {
 
 function closePageScreens() {
   closeCardModal(true);
-  closeDirectoryModal(true);
+  closeDirectoryModal?.(true);
   document.body.classList.remove('page-card-mode');
   document.body.classList.remove('page-directory-mode');
 }
@@ -3186,31 +3186,41 @@ function createEmptyCardDraft(cardType = 'MK') {
   };
 }
 
+const CARD_SECTION_KEYS = ['main', 'materials', 'items', 'responsible', 'operations'];
+
 function cardSectionLabel(sectionKey) {
   const labels = {
-    main: 'Основная информация',
-    operations: 'Операции',
-    add: 'Добавление операций'
+    main: 'Основные данные',
+    materials: 'Материалы',
+    items: 'Изделия',
+    responsible: 'Ответственные',
+    operations: 'Операции'
   };
   return labels[sectionKey] || labels.main;
 }
 
 function updateCardSectionsVisibility() {
-  const sections = document.querySelectorAll('#card-modal .card-section');
-  const isMobile = window.innerWidth <= 768;
+  const sections = document.querySelectorAll('#card-modal .card-tab-panel[data-section]');
   sections.forEach(section => {
     const key = section.dataset.section;
     if (!key) return;
-    if (isMobile) {
-      const isActive = key === cardActiveSectionKey;
-      section.classList.toggle('active', isActive);
-      section.hidden = !isActive;
-    } else {
-      section.classList.add('active');
-      section.hidden = false;
-    }
+    const isActive = key === cardActiveSectionKey;
+    section.classList.toggle('active', isActive);
+    section.hidden = !isActive;
   });
   updateCardSectionMenuItems();
+  updateCardTabButtons();
+}
+
+function updateCardTabButtons() {
+  const buttons = document.querySelectorAll('.card-tab-btn[data-tab]');
+  buttons.forEach(btn => {
+    const key = btn.getAttribute('data-tab');
+    const isActive = key === cardActiveSectionKey;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    btn.tabIndex = isActive ? 0 : -1;
+  });
 }
 
 function updateCardSectionMenuItems() {
@@ -3226,12 +3236,11 @@ function updateCardSectionMenuItems() {
 }
 
 function setActiveCardSection(sectionKey = 'main') {
-  cardActiveSectionKey = sectionKey;
+  cardActiveSectionKey = CARD_SECTION_KEYS.includes(sectionKey) ? sectionKey : 'main';
   const labelEl = document.getElementById('card-mobile-active-label');
   if (labelEl) {
     labelEl.textContent = cardSectionLabel(cardActiveSectionKey);
   }
-  updateCardSectionMenuItems();
   updateCardSectionsVisibility();
 }
 
@@ -3270,6 +3279,16 @@ function setupCardSectionMenu() {
   });
 
   window.addEventListener('resize', () => updateCardSectionsVisibility());
+}
+
+function setupCardTabsNavigation() {
+  const tabButtons = document.querySelectorAll('.card-tab-btn[data-tab]');
+  tabButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.getAttribute('data-tab');
+      setActiveCardSection(tab);
+    });
+  });
 }
 
 function openCardModal(cardId, options = {}) {
@@ -3361,9 +3380,14 @@ function closeCardModal(silent = false) {
   const modal = document.getElementById('card-modal');
   if (!modal) return;
   modal.classList.add('hidden');
-  document.getElementById('card-form').reset();
-  document.getElementById('route-form').reset();
-  document.getElementById('route-table-wrapper').innerHTML = '';
+  const cardForm = document.getElementById('card-form');
+  if (cardForm && typeof cardForm.reset === 'function') cardForm.reset();
+
+  const routeForm = document.getElementById('route-form');
+  if (routeForm && typeof routeForm.reset === 'function') routeForm.reset();
+
+  const routeWrap = document.getElementById('route-table-wrapper');
+  if (routeWrap) routeWrap.innerHTML = '';
   setCardMainCollapsed(false);
   closeImdxImportModal();
   closeImdxMissingModal();
@@ -7207,6 +7231,7 @@ function setupForms() {
   }
 
   setupCardSectionMenu();
+  setupCardTabsNavigation();
 
   const cardForm = document.getElementById('card-form');
   if (cardForm) {

--- a/index.html
+++ b/index.html
@@ -79,16 +79,6 @@
     </div>
   </div>
 
-  <div id="help-overlay" class="auth-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="help-modal-title" aria-hidden="true">
-    <div class="help-modal" id="help-modal" tabindex="-1">
-      <div class="help-modal__header">
-        <h2 id="help-modal-title">Инструкция по использованию</h2>
-        <button id="help-close" class="help-close" aria-label="Закрыть инструкцию">×</button>
-      </div>
-      <div id="help-content" class="help-modal__body" aria-live="polite"></div>
-    </div>
-  </div>
-
   <div id="barcode-scanner-modal" class="barcode-scanner-modal hidden" role="dialog" aria-modal="true" aria-live="polite" aria-label="Сканирование штрихкода">
     <div class="barcode-scanner-modal__backdrop"></div>
     <div class="barcode-scanner-modal__content">
@@ -305,221 +295,341 @@
         <div class="modal-body">
           <div class="card-mobile-menu" aria-label="Разделы создания карты">
             <button type="button" id="card-section-menu-toggle" class="btn-secondary card-menu-toggle" aria-expanded="false">☰ Разделы</button>
-            <span class="card-menu-active" id="card-mobile-active-label">Основная информация</span>
+            <span class="card-menu-active" id="card-mobile-active-label">Основные данные</span>
             <div class="card-section-menu" id="card-section-menu">
               <div class="card-section-menu-title">Навигация</div>
-              <button type="button" class="card-section-menu-item" data-section-target="main">Основная информация</button>
+              <button type="button" class="card-section-menu-item" data-section-target="main">Основные данные</button>
+              <button type="button" class="card-section-menu-item" data-section-target="materials">Материалы</button>
+              <button type="button" class="card-section-menu-item" data-section-target="items">Изделия</button>
+              <button type="button" class="card-section-menu-item" data-section-target="responsible">Ответственные</button>
               <button type="button" class="card-section-menu-item" data-section-target="operations">Операции</button>
-              <button type="button" class="card-section-menu-item" data-section-target="add">Добавление операций</button>
             </div>
           </div>
 
-          <div class="card-section card-section-main active" data-section="main">
-            <div class="card-main-collapse-block" id="card-main-block">
-              <div class="card-main-header">
-                <h3 class="card-main-title">Основные данные</h3>
-                <div class="card-main-summary" id="card-main-summary"></div>
-                <button type="button" id="card-main-toggle" class="btn-secondary card-main-toggle" aria-expanded="true">Свернуть</button>
-              </div>
-              <div class="card-main-collapse-body" id="card-main-body">
-                <form id="card-form" class="flex-col">
-                  <input type="hidden" id="card-id" />
-                  <div class="card-meta-grid card-meta-grid-compact">
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-route-number">Маршрутная карта №</label>
-                        <input id="card-route-number" />
-                      </div>
-                      <div class="flex-col">
-                        <label for="card-document-designation">Обозначение документа</label>
-                        <input id="card-document-designation" />
-                      </div>
-                      <div class="flex-col">
-                        <label for="card-date">Дата</label>
-                        <input id="card-date" type="date" />
-                      </div>
-                    </div>
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-issued-by">Фамилия выписавшего маршрутную карту</label>
-                        <input id="card-issued-by" />
-                      </div>
-                      <div class="flex-col">
-                        <label for="card-program-name">Название программы</label>
-                        <input id="card-program-name" />
-                      </div>
-                      <div class="flex-col">
-                        <label for="card-lab-request">Номер заявки лаборатории</label>
-                        <input id="card-lab-request" />
-                      </div>
-                    </div>
-                  </div>
+          <div class="card-page-grid">
+            <div class="card-layout-left">
+              <div class="card-tabs-layout">
+                <div class="card-folder-tabs card-tab-header" role="tablist" aria-label="Навигация по разделам карты">
+                  <button type="button" id="card-tab-btn-main" class="card-tab-btn active" data-tab="main" role="tab" aria-selected="true" aria-controls="card-tab-main">Основные данные</button>
+                  <button type="button" id="card-tab-btn-materials" class="card-tab-btn" data-tab="materials" role="tab" aria-selected="false" aria-controls="card-tab-materials">Материалы</button>
+                  <button type="button" id="card-tab-btn-items" class="card-tab-btn" data-tab="items" role="tab" aria-selected="false" aria-controls="card-tab-items">Изделия</button>
+                  <button type="button" id="card-tab-btn-responsible" class="card-tab-btn" data-tab="responsible" role="tab" aria-selected="false" aria-controls="card-tab-responsible">Ответственные</button>
+                  <button type="button" id="card-tab-btn-operations" class="card-tab-btn" data-tab="operations" role="tab" aria-selected="false" aria-controls="card-tab-operations">Операции</button>
+                </div>
 
-                  <div class="card-meta-grid card-meta-grid-compact">
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-work-basis">Основание для выполнения работ</label>
-                        <textarea id="card-work-basis" rows="3"></textarea>
-                      </div>
-                    </div>
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-supply-state">Состояние поставки</label>
-                        <input id="card-supply-state" />
-                      </div>
-                    </div>
-                  </div>
+                <div class="card-tab-surface">
+                  <div class="card-tab-panels">
+                    <form id="card-form" class="card-tab-form">
+                      <input type="hidden" id="card-id" />
+                      <div class="card-tab-panel card-section-main active" data-section="main" id="card-tab-main" role="tabpanel" aria-labelledby="card-tab-btn-main">
+                        <div class="card-main-collapse-block" id="card-main-block">
+                          <div class="card-main-header">
+                            <h3 class="card-main-title">Основные данные</h3>
+                            <div class="card-main-summary" id="card-main-summary"></div>
+                            <button type="button" id="card-main-toggle" class="btn-secondary card-main-toggle" aria-expanded="true">Свернуть</button>
+                          </div>
+                          <div class="card-main-collapse-body" id="card-main-body">
+                            <div class="card-meta-grid card-meta-grid-compact">
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-route-number">Маршрутная карта №</label>
+                                  <input id="card-route-number" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-document-designation">Обозначение документа</label>
+                                  <input id="card-document-designation" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-date">Дата</label>
+                                  <input id="card-date" type="date" />
+                                </div>
+                              </div>
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-issued-by">Фамилия выписавшего маршрутную карту</label>
+                                  <input id="card-issued-by" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-program-name">Название программы</label>
+                                  <input id="card-program-name" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-lab-request">Номер заявки лаборатории</label>
+                                  <input id="card-lab-request" />
+                                </div>
+                              </div>
+                            </div>
 
-                  <div class="card-meta-grid card-meta-grid-compact">
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-item-designation">Обозначение изделия</label>
-                        <input id="card-item-designation" />
-                      </div>
-                    </div>
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-supply-standard">НТД на поставку</label>
-                        <input id="card-supply-standard" />
-                      </div>
-                    </div>
-                  </div>
+                            <div class="card-meta-grid card-meta-grid-compact">
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-work-basis">Основание для выполнения работ</label>
+                                  <textarea id="card-work-basis" rows="3"></textarea>
+                                </div>
+                              </div>
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-supply-status">Состояние поставки</label>
+                                  <input id="card-supply-status" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-ntd">НТД на поставку</label>
+                                  <input id="card-ntd" />
+                                </div>
+                              </div>
+                            </div>
 
-                  <div class="flex-col">
-                    <label for="card-name">Наименование изделия</label>
-                    <textarea id="card-name" rows="2" required></textarea>
-                  </div>
+                            <div class="card-meta-grid card-meta-grid-compact">
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-product-name">Наименование изделия</label>
+                                  <input id="card-product-name" />
+                                </div>
+                              </div>
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-product-designation">Обозначение изделия</label>
+                                  <input id="card-product-designation" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-program-title">Название программы</label>
+                                  <input id="card-program-title" />
+                                </div>
+                              </div>
+                            </div>
 
-                  <div class="card-meta-grid card-meta-grid-compact">
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-main-materials">Основные материалы, применяемые в техпроцессе (согласно заказу на производство)</label>
-                        <textarea id="card-main-materials" rows="3"></textarea>
-                      </div>
-                    </div>
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-material">Марка основного материала</label>
-                        <input id="card-material" />
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="card-meta-grid card-meta-grid-compact">
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-qty">Размер партии</label>
-                        <input id="card-qty" type="number" min="0" step="1" />
-                      </div>
-                    </div>
-                    <div class="card-meta-col">
-                      <div class="flex-col">
-                        <label for="card-item-serials">Индивидуальные номера изделий</label>
-                        <textarea id="card-item-serials" rows="3" placeholder="Один номер на строку"></textarea>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="flex-col">
-                    <label for="card-desc">Особые отметки</label>
-                    <textarea id="card-desc"></textarea>
-                  </div>
-
-                  <div class="flex-col card-meta-responsible">
-                    <label>Ответственные лица (ФИО)</label>
-                    <div class="card-meta-grid card-meta-grid-compact">
-                      <div class="card-meta-col">
-                        <div class="flex-col">
-                          <label for="card-production-chief">Начальник производства (ФИО)</label>
-                          <input id="card-production-chief" />
+                            <div class="card-meta-grid card-meta-grid-compact">
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-special-notes">Особые отметки</label>
+                                  <textarea id="card-special-notes" rows="3"></textarea>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
-                      <div class="card-meta-col">
-                        <div class="flex-col">
-                          <label for="card-skk-chief">Начальник СКК (ФИО)</label>
-                          <input id="card-skk-chief" />
+                      <div class="card-tab-panel card-section-materials" data-section="materials" id="card-tab-materials" role="tabpanel" aria-labelledby="card-tab-btn-materials" hidden>
+                        <div class="card-info-collapse-block" id="card-info-block">
+                          <div class="card-main-header">
+                            <h3 class="card-main-title">Материалы</h3>
+                            <div class="card-main-summary" id="card-info-summary"></div>
+                            <button type="button" id="card-info-toggle" class="btn-secondary card-main-toggle" aria-expanded="true">Свернуть</button>
+                          </div>
+                          <div class="card-main-collapse-body" id="card-info-body">
+                            <div class="card-meta-grid card-meta-grid-compact">
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-base-material">Марка основного материала</label>
+                                  <input id="card-base-material" />
+                                </div>
+                              </div>
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-tech-materials">Основные материалы, применяемые в техпроцессе (согласно заказу на производство)</label>
+                                  <textarea id="card-tech-materials" rows="3"></textarea>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
-                      <div class="card-meta-col">
-                        <div class="flex-col">
-                          <label for="card-tech-lead">ЗГД по технологиям (ФИО)</label>
-                          <input id="card-tech-lead" />
+                      <div class="card-tab-panel card-section-items" data-section="items" id="card-tab-items" role="tabpanel" aria-labelledby="card-tab-btn-items" hidden>
+                        <div class="card-info-collapse-block" id="card-items-block">
+                          <div class="card-main-header">
+                            <h3 class="card-main-title">Изделия</h3>
+                            <div class="card-main-summary" id="card-items-summary"></div>
+                            <button type="button" id="card-items-toggle" class="btn-secondary card-main-toggle" aria-expanded="true">Свернуть</button>
+                          </div>
+                          <div class="card-main-collapse-body" id="card-items-body">
+                            <div class="card-meta-grid card-meta-grid-compact">
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-batch-size">Размер партии</label>
+                                  <input id="card-batch-size" type="number" min="1" value="1" />
+                                </div>
+                              </div>
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-item-numbers">Индивидуальные номера изделий</label>
+                                  <textarea id="card-item-numbers" rows="3" placeholder="Перечислите номера изделий через запятую или пробел" aria-describedby="card-item-numbers-hint"></textarea>
+                                  <small id="card-item-numbers-hint" class="hint">Пример: №4, №5, №6</small>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
-                    </div>
+                      <div class="card-tab-panel card-section-responsible" data-section="responsible" id="card-tab-responsible" role="tabpanel" aria-labelledby="card-tab-btn-responsible" hidden>
+                        <div class="card-info-collapse-block" id="card-responsible-block">
+                          <div class="card-main-header">
+                            <h3 class="card-main-title">Ответственные</h3>
+                            <div class="card-main-summary" id="card-responsible-summary"></div>
+                            <button type="button" id="card-responsible-toggle" class="btn-secondary card-main-toggle" aria-expanded="true">Свернуть</button>
+                          </div>
+                          <div class="card-main-collapse-body" id="card-responsible-body">
+                            <div class="card-meta-grid card-meta-grid-compact">
+                              <div class="card-meta-col">
+                                <div class="flex-col">
+                                  <label for="card-responsible-person">Ответственные лица (ФИО)</label>
+                                  <input id="card-responsible-person" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-production-chief">Начальник производства (ФИО)</label>
+                                  <input id="card-production-chief" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-ntc-chief">Начальник СКК (ФИО)</label>
+                                  <input id="card-ntc-chief" />
+                                </div>
+                                <div class="flex-col">
+                                  <label for="card-tech-chief">ЗГД по технологиям (ФИО)</label>
+                                  <input id="card-tech-chief" />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="card-tab-panel card-section-operations" data-section="operations" id="card-tab-operations" role="tabpanel" aria-labelledby="card-tab-btn-operations" hidden>
+                        <div class="card-section card-section-operations">
+                          <div class="card-section-header">
+                            <div>
+                              <h3 class="card-section-title">Маршрут выполнения операций</h3>
+                              <p class="card-section-subtitle">Операции, их типы, цеха и исполнители</p>
+                            </div>
+                            <div class="card-section-actions">
+                              <button type="button" id="card-add-executor-btn" class="btn-secondary">Групповой исполнитель</button>
+                            </div>
+                          </div>
+                          <div class="route-table-wrapper" id="route-table-wrapper"></div>
+                        </div>
+                        <div class="card inset-card card-section card-section-add active">
+                          <div class="card-section-header">
+                            <div>
+                              <h3 class="card-section-title">Добавление операции</h3>
+                              <p class="card-section-subtitle">Код операции, цех, рабочее место и исполнители</p>
+                            </div>
+                            <div class="card-section-actions">
+                              <button type="button" id="route-editor-collapse-btn" class="btn-secondary">Свернуть</button>
+                            </div>
+                          </div>
+                          <form id="route-editor" class="card-section-body">
+                            <div class="flex-col">
+                              <label for="route-operation">Операция</label>
+                              <div class="combo-field">
+                                <input id="route-operation" list="operations-combobox-options" required />
+                                <datalist id="operations-combobox-options"></datalist>
+                              </div>
+                            </div>
+                            <div class="card-grid">
+                              <div class="flex-col">
+                                <label for="route-code">Код операции</label>
+                                <input id="route-code" required />
+                              </div>
+                              <div class="flex-col">
+                                <label for="route-center">Цех</label>
+                                <div class="combo-field">
+                                  <input id="route-center" list="centers-combobox-options" required />
+                                  <datalist id="centers-combobox-options"></datalist>
+                                </div>
+                              </div>
+                            </div>
+                            <div class="card-grid">
+                              <div class="flex-col">
+                                <label for="route-workspace">Рабочее место</label>
+                                <div class="combo-field">
+                                  <input id="route-workspace" list="workspaces-combobox-options" required />
+                                  <datalist id="workspaces-combobox-options"></datalist>
+                                </div>
+                              </div>
+                              <div class="flex-col">
+                                <label for="route-type">Тип операции</label>
+                                <select id="route-type" required>
+                                  <option value="primary">Первичная</option>
+                                  <option value="secondary">Вторичная</option>
+                                  <option value="nc">Неразрушающий контроль</option>
+                                </select>
+                              </div>
+                            </div>
+                            <div class="card-grid">
+                              <div class="flex-col">
+                                <label for="route-serial">Серийность</label>
+                                <select id="route-serial" required>
+                                  <option value="single">Разовая</option>
+                                  <option value="small">Мелкосерийная</option>
+                                  <option value="mass">Массовая</option>
+                                </select>
+                              </div>
+                              <div class="flex-col">
+                                <label for="route-qty">Количество</label>
+                                <input id="route-qty" type="number" min="1" value="1" required />
+                              </div>
+                              <div class="flex-col">
+                                <label for="route-duration">Длительность (мин)</label>
+                                <input id="route-duration" type="number" min="1" value="30" required />
+                              </div>
+                            </div>
+                            <div class="card-grid">
+                              <div class="flex-col">
+                                <label for="route-author">Внес в МК</label>
+                                <div class="combo-field">
+                                  <input id="route-author" list="user-combobox-options" />
+                                  <datalist id="user-combobox-options"></datalist>
+                                </div>
+                              </div>
+                              <div class="flex-col">
+                                <label for="route-executor">Исполнитель</label>
+                                <div class="combo-field">
+                                  <input id="route-executor" list="user-combobox-options" />
+                                </div>
+                              </div>
+                            </div>
+                            <div class="card-grid">
+                              <div class="flex-col">
+                                <label for="route-planned">Плановое время (мин)</label>
+                                <input id="route-planned" type="number" min="1" value="30" required />
+                              </div>
+                              <div class="flex-col" style="flex:0 0 auto; align-self:flex-end;">
+                                <button type="submit" class="btn-primary">Добавить</button>
+                              </div>
+                            </div>
+                          </form>
+                        </div>
+                      </div>
+                    </form>
                   </div>
-                </form>
+                </div>
               </div>
             </div>
-            <div class="card-status-row">
-              <div>
-                <strong>Статус:</strong> <span id="card-status-text"></span>
+            <aside class="card-layout-right">
+              <div class="card-rail card-rail-status">
+                <div class="card-status-row">
+                  <div>
+                    <strong>Статус:</strong> <span id="card-status-text"></span>
+                  </div>
+                  <div class="flex" style="gap:8px; align-items:center;">
+                    <label class="toggle-row" title="Добавить в маршрут список изделий">
+                      <input type="checkbox" id="card-use-items" />
+                      <span>Список изделий</span>
+                    </label>
+                    <button type="button" id="card-attachments-btn" class="btn-secondary">📎 Файлы (0)</button>
+                  </div>
+                </div>
               </div>
-              <div class="flex" style="gap:8px; align-items:center;">
-                <label class="toggle-row" title="Добавить в маршрут список изделий">
-                  <input type="checkbox" id="card-use-items" />
-                  <span>Список изделий</span>
-                </label>
-                <button type="button" id="card-attachments-btn" class="btn-secondary">📎 Файлы (0)</button>
-              </div>
-            </div>
-          </div>
 
-          <div id="route-editor">
-            <div class="card inset-card card-section card-section-operations" data-section="operations">
-              <h3>Маршрут выполнения операций</h3>
-              <div id="route-table-wrapper" class="table-wrapper"></div>
-            </div>
-            <div class="card inset-card card-section card-section-add" data-section="add">
-              <h3>Добавление операций</h3>
-              <div class="route-add-panel">
-                <h3>Добавить операцию в маршрут</h3>
-                <form id="route-form" class="flex route-form-grid" style="flex-wrap:wrap;">
-                  <div class="flex-col" style="flex:1 1 140px;">
-                    <label for="route-op-code">Код операции</label>
-                    <input id="route-op-code" placeholder="Напишите код" />
-                  </div>
-                  <div class="flex-col" style="flex:2 1 200px;">
-                    <label for="route-op">Операции</label>
-                    <div class="combo-field">
-                      <input id="route-op" list="route-op-options" placeholder="Начните вводить название или код" required />
-                      <div class="combo-suggestions" id="route-op-suggestions" role="listbox"></div>
-                    </div>
-                    <datalist id="route-op-options"></datalist>
-                  </div>
-                  <div class="flex-col" style="flex:2 1 200px;">
-                    <label for="route-center">Подразделения</label>
-                    <div class="combo-field">
-                      <input id="route-center" list="route-center-options" placeholder="Начните вводить подразделение" required />
-                      <div class="combo-suggestions" id="route-center-suggestions" role="listbox"></div>
-                    </div>
-                    <datalist id="route-center-options"></datalist>
-                  </div>
-                  <div class="flex-col" style="flex:1 1 140px;">
-                    <label for="route-qty">Количество изделий</label>
-                    <input id="route-qty" type="number" min="0" />
-                  </div>
-                  <div class="flex-col" style="flex:1 1 120px;">
-                    <label for="route-planned">Плановое время (мин)</label>
-                    <input id="route-planned" type="number" min="1" value="30" required />
-                  </div>
-                  <div class="flex-col" style="flex:0 0 auto; align-self:flex-end;">
-                    <button type="submit" class="btn-primary">Добавить</button>
-                  </div>
-                </form>
+              <div class="card-rail card-rail-actions modal-actions card-modal-actions">
+                <div class="modal-actions-left">
+                  <button type="button" id="card-create-group-btn" class="btn-secondary">Создать группу карт</button>
+                </div>
+                <div class="modal-actions-right">
+                  <button type="button" id="card-import-imdx-btn" class="btn-secondary">Импорт (IMDX)</button>
+                  <button type="button" id="card-save-btn" class="btn-primary">Сохранить карту</button>
+                  <button type="button" id="card-print-btn" class="btn-secondary">Печать</button>
+                  <button type="button" id="card-cancel-btn" class="btn-secondary">Закрыть</button>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
-        <div class="modal-actions card-modal-actions">
-          <div class="modal-actions-left">
-            <button type="button" id="card-create-group-btn" class="btn-secondary">Создать группу карт</button>
-          </div>
-          <div class="modal-actions-right">
-            <button type="button" id="card-import-imdx-btn" class="btn-secondary">Импорт (IMDX)</button>
-            <button type="button" id="card-save-btn" class="btn-primary">Сохранить карту</button>
-            <button type="button" id="card-print-btn" class="btn-secondary">Печать</button>
-            <button type="button" id="card-cancel-btn" class="btn-secondary">Закрыть</button>
+            </aside>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -31,6 +31,9 @@ header {
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  z-index: 1600;
 }
 
 .header-left {
@@ -244,7 +247,7 @@ header h1 {
   min-width: 200px;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
   display: none;
-  z-index: 50;
+  z-index: 2000;
 }
 
 .nav-dropdown-menu.open {
@@ -401,6 +404,10 @@ main {
   max-width: 1200px;
   width: min(1200px, 100%);
   margin: 0 auto;
+}
+
+body.page-card-mode {
+  overflow-x: hidden;
 }
 
 body.page-card-mode main,
@@ -1126,6 +1133,235 @@ tbody tr:nth-child(even) {
   gap: 10px;
 }
 
+.card-page-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  grid-template-areas: 'left right';
+  align-items: start;
+  gap: 16px;
+  width: 100%;
+  overflow-x: hidden;
+}
+
+.card-layout-left {
+  grid-area: left;
+  min-width: 0;
+}
+
+.card-layout-right {
+  grid-area: right;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card-rail {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.04);
+}
+
+.card-rail-status {
+  position: sticky;
+  top: 0;
+}
+
+.card-rail-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: stretch;
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+  justify-content: flex-start;
+}
+
+.card-rail-actions .modal-actions-left,
+.card-rail-actions .modal-actions-right {
+  justify-content: stretch;
+  flex-wrap: wrap;
+}
+
+.card-rail-actions .modal-actions-left button,
+.card-rail-actions .modal-actions-right button {
+  flex: 1 1 140px;
+}
+
+.card-folder-tabs {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0 0 12px;
+  padding: 0;
+}
+
+.card-tab-btn {
+  position: relative;
+  border: 1px solid #d1d5db;
+  border-bottom: none;
+  padding: 10px 16px;
+  background: linear-gradient(180deg, #f9fafb 0%, #e5e7eb 100%);
+  color: #111827;
+  border-radius: 10px 10px 0 0;
+  clip-path: polygon(10px 100%, 0 26px, 0 0, 100% 0, 100% calc(100% - 8px), calc(100% - 10px) 100%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  z-index: 1;
+  flex: 0 1 180px;
+}
+
+.card-tab-btn:not(.active) {
+  color: #4b5563;
+  transform: translateY(6px);
+  background: linear-gradient(180deg, #f3f4f6 0%, #e5e7eb 100%);
+}
+
+.card-tab-btn.active {
+  background: #fff;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  z-index: 2;
+  transform: translateY(0);
+}
+
+.card-tab-btn:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.card-tab-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.card-tab-form {
+  display: contents;
+}
+
+.card-tab-panel {
+  display: none;
+  position: relative;
+  min-width: 0;
+}
+
+.card-tab-panel.active {
+  display: block;
+}
+
+.card-tab-surface {
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 0 12px 12px 12px;
+  padding: 12px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.05);
+  min-width: 0;
+}
+
+.card-tab-panel .card-section {
+  display: block;
+}
+
+.card-tab-panel .table-wrapper {
+  overflow-x: hidden;
+  padding-bottom: 0;
+}
+
+.card-tab-panel table {
+  min-width: 0;
+  table-layout: fixed;
+  word-break: break-word;
+}
+
+.card-tab-panel th,
+.card-tab-panel td {
+  white-space: normal;
+}
+
+.card-tab-panel:not(.active) #route-editor,
+.card-tab-panel:not(.active) .card-section-operations,
+.card-tab-panel:not(.active) .card-section-add {
+  display: none !important;
+}
+
+/* ЕДИНАЯ “ПОВЕРХНОСТЬ” ВКЛАДКИ — главный цельный контур */
+.card-tab-surface {
+  border: 2px solid #9ca3af;
+  border-radius: 10px;
+  background: #fff;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+  margin-top: -2px;
+}
+
+/* ВКЛАДКИ — стыкуем с поверхностью и делаем единый контур */
+.card-tab-btn {
+  border: 2px solid #9ca3af;
+}
+
+.card-tab-btn.active {
+  border-bottom: none;
+  position: relative;
+  z-index: 2;
+}
+
+/* Неактивные вкладки можно сделать менее контрастными */
+.card-tab-btn:not(.active) {
+  border-color: #d1d5db;
+}
+
+/* УБИРАЕМ ВНУТРЕННИЕ “КАРТОЧКИ”, КОТОРЫЕ ДРОБЯТ РАМКУ */
+.card-tab-panel .card-main-collapse-block,
+.card-tab-panel .card-info-collapse-block {
+  border: none !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  margin: 0 !important;
+}
+
+/* Убираем разрывы снизу из-за margin у карточек внутри панели */
+.card-tab-panel .card,
+.card-tab-panel .inset-card {
+  margin-bottom: 0 !important;
+}
+
+@media (max-width: 1200px) {
+  .card-page-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'right'
+      'left';
+  }
+
+  .card-layout-right {
+    position: relative;
+  }
+
+  .card-rail-status {
+    position: static;
+  }
+}
+
+@media (max-width: 900px) {
+  .card-folder-tabs {
+    gap: 6px;
+  }
+
+  .card-tab-btn {
+    flex: 1 1 140px;
+  }
+
+  .card-rail-actions .modal-actions-left button,
+  .card-rail-actions .modal-actions-right button {
+    flex: 1 1 120px;
+  }
+}
+
 @media (min-width: 1025px) {
   .card-modal-content {
     height: 92vh;
@@ -1384,11 +1620,13 @@ tbody tr:nth-child(even) {
   position: static;
   inset: auto;
   background: transparent;
-  display: flex;
+  display: block;
   align-items: stretch;
   justify-content: center;
   padding: 0;
   box-shadow: none;
+  z-index: auto;
+  pointer-events: auto;
 }
 
 .modal.page-mode .modal-content {
@@ -1682,6 +1920,16 @@ body.page-directory-mode #cards {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+#card-modal .modal-body {
+  overflow-x: hidden;
+}
+
+@media (min-width: 1025px) {
+  #card-modal .modal-body {
+    overflow-y: auto;
+  }
 }
 
 .modal-actions {
@@ -2586,11 +2834,15 @@ footer {
     flex: 1 1 auto;
   }
 
-  #card-modal .card-section {
+  #card-modal .card-tab-panel {
     display: none;
   }
 
-  #card-modal .card-section.active {
+  #card-modal .card-tab-panel.active {
+    display: block;
+  }
+
+  #card-modal .card-tab-panel .card-section {
     display: block;
   }
 


### PR DESCRIPTION
## Summary
- guard modal-close logic against missing card and route forms and optional directory modal
- remove duplicate help overlay markup to ensure unique IDs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69445bd79c388328b50f2bf7e4cf750e)