### PR TITLE
Add MKI item and sample serial tables

### DIFF
--- a/app.js
+++ b/app.js
@@ -622,6 +622,35 @@ function clampToSafeCount(val, max) {
   return Math.min(safe, max);
 }
 
+function normalizeSerialInput(value) {
+  if (Array.isArray(value)) return value.map(v => (v == null ? '' : String(v).trim()));
+  if (typeof value === 'string') {
+    return value.split(/\r?\n|,/).map(v => v.trim());
+  }
+  return [];
+}
+
+function resizeSerialList(list, targetLength, { fillDefaults = false } = {}) {
+  const safeList = Array.isArray(list) ? list : [];
+  const length = Math.max(0, targetLength || 0);
+  const result = [];
+  for (let i = 0; i < length; i++) {
+    if (i < safeList.length) {
+      const val = safeList[i];
+      result.push(val == null ? '' : String(val));
+    } else if (fillDefaults) {
+      result.push('Без номера ' + (i + 1));
+    } else {
+      result.push('');
+    }
+  }
+  return result;
+}
+
+function hasEmptySerial(values = []) {
+  return (values || []).some(v => !String(v || '').trim());
+}
+
 function looksLikeLegacyBarcode(code) {
   return /^\d{13}$/.test((code || '').trim());
 }
@@ -872,6 +901,7 @@ function ensureCardMeta(card, options = {}) {
   if (!card) return;
   const { skipSnapshot = false } = options;
   card.cardType = card.cardType === 'MKI' ? 'MKI' : 'MK';
+  const isMki = card.cardType === 'MKI';
   card.routeCardNumber = typeof card.routeCardNumber === 'string'
     ? card.routeCardNumber
     : (card.orderNo ? String(card.orderNo) : '');
@@ -902,7 +932,20 @@ function ensureCardMeta(card, options = {}) {
   const qtyVal = card.batchSize === '' ? '' : toSafeCount(card.batchSize);
   card.quantity = qtyVal;
   card.batchSize = card.quantity;
-  card.itemSerials = typeof card.itemSerials === 'string' ? card.itemSerials : '';
+  if (isMki) {
+    const normalizedItems = normalizeSerialInput(card.itemSerials);
+    const itemCount = card.quantity === '' ? 0 : toSafeCount(card.quantity);
+    card.itemSerials = resizeSerialList(normalizedItems, itemCount, { fillDefaults: true });
+
+    const normalizedSamples = normalizeSerialInput(card.sampleSerials);
+    card.sampleCount = card.sampleCount === '' || card.sampleCount == null ? '' : toSafeCount(card.sampleCount);
+    const sampleCount = card.sampleCount === '' ? 0 : toSafeCount(card.sampleCount);
+    card.sampleSerials = resizeSerialList(normalizedSamples, sampleCount, { fillDefaults: true });
+  } else {
+    card.itemSerials = typeof card.itemSerials === 'string' ? card.itemSerials : '';
+    card.sampleCount = '';
+    card.sampleSerials = [];
+  }
   card.specialNotes = typeof card.specialNotes === 'string'
     ? card.specialNotes
     : (card.desc ? String(card.desc) : '');
@@ -962,6 +1005,15 @@ function formatCardTitle(card) {
   return card?.name ? String(card.name) : 'Маршрутная карта';
 }
 
+function formatItemSerialsValue(card) {
+  if (!card) return '';
+  const raw = resolveCardField(card, 'itemSerials');
+  if (Array.isArray(raw)) {
+    return raw.map(v => (v == null ? '' : String(v))).join(', ');
+  }
+  return typeof raw === 'string' ? raw : '';
+}
+
 function getCardItemName(card) {
   if (!card) return '';
   return (card.itemName || card.name || '').toString().trim();
@@ -984,6 +1036,27 @@ function validateMkiRouteCardNumber(draft, allCards) {
 
   if (conflict) {
     return 'Нельзя создать МКИ с номером маршрутной карты, совпадающим с номером обычной МК.';
+  }
+
+  return null;
+}
+
+function validateMkiDraftConstraints(draft) {
+  if (!draft || draft.cardType !== 'MKI') return null;
+  const qty = draft.quantity === '' ? 0 : toSafeCount(draft.quantity);
+  if (qty === 0) {
+    return 'Размер партии не может быть равен 0';
+  }
+
+  const normalizedItems = resizeSerialList(normalizeSerialInput(draft.itemSerials), qty, { fillDefaults: false });
+  if (hasEmptySerial(normalizedItems)) {
+    return 'Заполните все значения в таблице "Индивидуальные номера изделий".';
+  }
+
+  const sampleCount = draft.sampleCount === '' ? 0 : toSafeCount(draft.sampleCount);
+  const normalizedSamples = resizeSerialList(normalizeSerialInput(draft.sampleSerials), sampleCount, { fillDefaults: false });
+  if (hasEmptySerial(normalizedSamples)) {
+    return 'Заполните все значения в таблице "Индивидуальные номера образцов".';
   }
 
   return null;
@@ -3164,9 +3237,11 @@ function createEmptyCardDraft(cardType = 'MK') {
     mainMaterials: '',
     mainMaterialGrade: '',
     batchSize: '',
-    itemSerials: '',
+    itemSerials: normalizedType === 'MKI' ? [] : '',
     specialNotes: '',
     quantity: '',
+    sampleCount: '',
+    sampleSerials: [],
     useItemList: false,
     drawing: '',
     material: '',
@@ -3328,7 +3403,17 @@ function openCardModal(cardId, options = {}) {
   document.getElementById('card-main-materials').value = activeCardDraft.mainMaterials || '';
   document.getElementById('card-material').value = activeCardDraft.mainMaterialGrade || '';
   document.getElementById('card-qty').value = activeCardDraft.quantity != null ? activeCardDraft.quantity : '';
-  document.getElementById('card-item-serials').value = activeCardDraft.itemSerials || '';
+  const serialsTextarea = document.getElementById('card-item-serials');
+  if (serialsTextarea) {
+    const serialValue = Array.isArray(activeCardDraft.itemSerials)
+      ? activeCardDraft.itemSerials.join('\n')
+      : (activeCardDraft.itemSerials || '');
+    serialsTextarea.value = serialValue;
+  }
+  const sampleQtyInput = document.getElementById('card-sample-qty');
+  if (sampleQtyInput) {
+    sampleQtyInput.value = activeCardDraft.sampleCount != null ? activeCardDraft.sampleCount : '';
+  }
   document.getElementById('card-production-chief').value = activeCardDraft.responsibleProductionChief || '';
   document.getElementById('card-skk-chief').value = activeCardDraft.responsibleSKKChief || '';
   document.getElementById('card-tech-lead').value = activeCardDraft.responsibleTechLead || '';
@@ -3363,6 +3448,8 @@ function openCardModal(cardId, options = {}) {
   setCardMainCollapsed(false);
   renderRouteTableDraft();
   fillRouteSelectors();
+  setProductsLayoutMode(activeCardDraft.cardType);
+  renderMkiSerialTables();
   if (typeof window.openTab === 'function') {
     window.openTab(null, 'tab-main');
   }
@@ -3438,6 +3525,12 @@ async function saveCardDraft(options = {}) {
   recalcCardStatus(draft);
   ensureCardMeta(draft, { skipSnapshot: true });
 
+  const mkiValidationError = validateMkiDraftConstraints(draft);
+  if (mkiValidationError) {
+    alert(mkiValidationError);
+    return null;
+  }
+
   const mkiConflictError = validateMkiRouteCardNumber(draft, cards);
   if (mkiConflictError) {
     alert(mkiConflictError);
@@ -3507,7 +3600,24 @@ function syncCardDraftFromForm() {
   const qtyVal = qtyRaw === '' ? '' : Math.max(0, parseInt(qtyRaw, 10) || 0);
   activeCardDraft.quantity = Number.isFinite(qtyVal) ? qtyVal : '';
   activeCardDraft.batchSize = activeCardDraft.quantity;
-  activeCardDraft.itemSerials = document.getElementById('card-item-serials').value.trim();
+  if (activeCardDraft.cardType === 'MKI') {
+    const sampleRaw = document.getElementById('card-sample-qty').value.trim();
+    const sampleVal = sampleRaw === '' ? '' : Math.max(0, parseInt(sampleRaw, 10) || 0);
+    activeCardDraft.sampleCount = Number.isFinite(sampleVal) ? sampleVal : '';
+
+    activeCardDraft.itemSerials = collectSerialValuesFromTable('card-item-serials-table');
+    activeCardDraft.sampleSerials = collectSerialValuesFromTable('card-sample-serials-table');
+    const normalizedItems = normalizeSerialInput(activeCardDraft.itemSerials);
+    const normalizedSamples = normalizeSerialInput(activeCardDraft.sampleSerials);
+    const qtyCount = activeCardDraft.quantity === '' ? 0 : toSafeCount(activeCardDraft.quantity);
+    const sampleCount = activeCardDraft.sampleCount === '' ? 0 : toSafeCount(activeCardDraft.sampleCount);
+    activeCardDraft.itemSerials = resizeSerialList(normalizedItems, qtyCount, { fillDefaults: true });
+    activeCardDraft.sampleSerials = resizeSerialList(normalizedSamples, sampleCount, { fillDefaults: true });
+  } else {
+    activeCardDraft.itemSerials = document.getElementById('card-item-serials').value.trim();
+    activeCardDraft.sampleCount = '';
+    activeCardDraft.sampleSerials = [];
+  }
   activeCardDraft.specialNotes = document.getElementById('card-desc').value.trim();
   activeCardDraft.desc = activeCardDraft.specialNotes;
   activeCardDraft.responsibleProductionChief = document.getElementById('card-production-chief').value.trim();
@@ -3518,6 +3628,61 @@ function syncCardDraftFromForm() {
   activeCardDraft.useItemList = useItemsCheckbox ? useItemsCheckbox.checked : false;
   if (prevUseList !== activeCardDraft.useItemList && Array.isArray(activeCardDraft.operations)) {
     activeCardDraft.operations.forEach(op => normalizeOperationItems(activeCardDraft, op));
+  }
+}
+
+function collectSerialValuesFromTable(tableId) {
+  const table = document.getElementById(tableId);
+  if (!table) return [];
+  return Array.from(table.querySelectorAll('.serials-input')).map(input => input.value || '');
+}
+
+function renderSerialsTable(tableId, values = []) {
+  const rows = (values || []).map((val, idx) => {
+    return '<tr>' +
+      '<td class="serials-index-cell">' + (idx + 1) + '.</td>' +
+      '<td class="serials-input-cell">' +
+        '<input class="serials-input" data-index="' + idx + '" value="' + escapeHtml(val || '') + '" placeholder="Без номера ' + (idx + 1) + '">' +
+      '</td>' +
+    '</tr>';
+  }).join('');
+  return '<table id="' + tableId + '" class="serials-table"><tbody>' + rows + '</tbody></table>';
+}
+
+function setProductsLayoutMode(cardType) {
+  const isMki = cardType === 'MKI';
+  const tab = document.getElementById('tab-products');
+  if (tab) tab.classList.toggle('mki-mode', isMki);
+  const serialsTableWrapper = document.getElementById('card-item-serials-table-wrapper');
+  if (serialsTableWrapper) serialsTableWrapper.classList.toggle('hidden', !isMki);
+  const serialsTextarea = document.getElementById('card-item-serials');
+  if (serialsTextarea) serialsTextarea.classList.toggle('hidden', isMki);
+  const sampleQtyField = document.getElementById('field-sample-qty');
+  if (sampleQtyField) sampleQtyField.classList.toggle('hidden', !isMki);
+  const sampleSerialsField = document.getElementById('field-sample-serials');
+  if (sampleSerialsField) sampleSerialsField.classList.toggle('hidden', !isMki);
+}
+
+function renderMkiSerialTables() {
+  if (!activeCardDraft || activeCardDraft.cardType !== 'MKI') return;
+  const qty = activeCardDraft.quantity === '' ? 0 : toSafeCount(activeCardDraft.quantity);
+  const normalizedItems = normalizeSerialInput(activeCardDraft.itemSerials);
+  activeCardDraft.itemSerials = resizeSerialList(normalizedItems, qty, { fillDefaults: true });
+  const itemWrapper = document.getElementById('card-item-serials-table-wrapper');
+  if (itemWrapper) {
+    itemWrapper.innerHTML = renderSerialsTable('card-item-serials-table', activeCardDraft.itemSerials);
+  }
+
+  const sampleCount = activeCardDraft.sampleCount === '' ? 0 : toSafeCount(activeCardDraft.sampleCount);
+  const normalizedSamples = normalizeSerialInput(activeCardDraft.sampleSerials);
+  activeCardDraft.sampleSerials = resizeSerialList(normalizedSamples, sampleCount, { fillDefaults: true });
+  const sampleField = document.getElementById('field-sample-serials');
+  if (sampleField) sampleField.classList.toggle('hidden', sampleCount === 0);
+  const sampleWrapper = document.getElementById('card-sample-serials-table-wrapper');
+  if (sampleWrapper) {
+    sampleWrapper.innerHTML = sampleCount > 0
+      ? renderSerialsTable('card-sample-serials-table', activeCardDraft.sampleSerials)
+      : '';
   }
 }
 
@@ -3540,6 +3705,8 @@ function logCardDifferences(original, updated) {
     'mainMaterialGrade',
     'batchSize',
     'itemSerials',
+    'sampleCount',
+    'sampleSerials',
     'specialNotes',
     'responsibleProductionChief',
     'responsibleSKKChief',
@@ -4133,6 +4300,13 @@ function closeLogModal(silent = false) {
 
 function printCardView(card) {
   if (!card || !card.id) return;
+  const draft = cloneCard(card);
+  ensureCardMeta(draft, { skipSnapshot: true });
+  const validationError = validateMkiDraftConstraints(draft);
+  if (validationError) {
+    alert(validationError);
+    return;
+  }
   const url = '/print/mk/' + encodeURIComponent(card.id);
   openPrintPreview(url);
 }
@@ -5239,7 +5413,7 @@ function buildCardInfoBlock(card, { collapsible = true, startCollapsed = false }
   const mainMaterials = resolveCardField(card, 'mainMaterials');
   const mainMaterialGrade = resolveCardField(card, 'mainMaterialGrade', 'material');
   const batchSize = resolveCardField(card, 'batchSize', 'quantity');
-  const itemSerials = resolveCardField(card, 'itemSerials');
+  const itemSerials = formatItemSerialsValue(card);
   const specialNotes = resolveCardField(card, 'specialNotes', 'desc');
   const responsibleProductionChief = resolveCardField(card, 'responsibleProductionChief');
   const responsibleSKKChief = resolveCardField(card, 'responsibleSKKChief');
@@ -7267,6 +7441,20 @@ function setupForms() {
       }
       updateCardMainSummary();
       renderRouteTableDraft();
+      if (activeCardDraft.cardType === 'MKI') {
+        renderMkiSerialTables();
+      }
+    });
+  }
+
+  const sampleQtyInput = document.getElementById('card-sample-qty');
+  if (sampleQtyInput) {
+    sampleQtyInput.addEventListener('input', e => {
+      if (!activeCardDraft || activeCardDraft.cardType !== 'MKI') return;
+      const raw = e.target.value.trim();
+      const qtyVal = raw === '' ? '' : Math.max(0, parseInt(raw, 10) || 0);
+      activeCardDraft.sampleCount = Number.isFinite(qtyVal) ? qtyVal : '';
+      renderMkiSerialTables();
     });
   }
 
@@ -7287,6 +7475,32 @@ function setupForms() {
         }
       }
       renderRouteTableDraft();
+    });
+  }
+
+  const itemSerialsWrapper = document.getElementById('card-item-serials-table-wrapper');
+  if (itemSerialsWrapper) {
+    itemSerialsWrapper.addEventListener('input', e => {
+      if (!activeCardDraft || activeCardDraft.cardType !== 'MKI') return;
+      const input = e.target.closest('.serials-input');
+      if (!input) return;
+      const idx = parseInt(input.dataset.index, 10);
+      if (!Number.isNaN(idx) && idx >= 0) {
+        activeCardDraft.itemSerials[idx] = input.value;
+      }
+    });
+  }
+
+  const sampleSerialsWrapper = document.getElementById('card-sample-serials-table-wrapper');
+  if (sampleSerialsWrapper) {
+    sampleSerialsWrapper.addEventListener('input', e => {
+      if (!activeCardDraft || activeCardDraft.cardType !== 'MKI') return;
+      const input = e.target.closest('.serials-input');
+      if (!input) return;
+      const idx = parseInt(input.dataset.index, 10);
+      if (!Number.isNaN(idx) && idx >= 0) {
+        activeCardDraft.sampleSerials[idx] = input.value;
+      }
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -416,13 +416,24 @@
 
                 <!-- 4.3 Изделия -->
                 <div id="tab-products" class="tab-pane">
-                    <div class="flex-col">
+                    <div class="products-layout" id="products-layout">
+                      <div class="flex-col product-field" id="field-batch-size">
                         <label for="card-qty">Размер партии</label>
                         <input id="card-qty" type="number" min="0" step="1" form="card-form" />
-                    </div>
-                    <div class="flex-col">
+                      </div>
+                      <div class="flex-col product-field" id="field-item-serials">
                         <label for="card-item-serials">Индивидуальные номера изделий</label>
                         <textarea id="card-item-serials" rows="3" placeholder="Один номер на строку" form="card-form"></textarea>
+                        <div id="card-item-serials-table-wrapper" class="serials-table-wrapper hidden"></div>
+                      </div>
+                      <div class="flex-col product-field hidden" id="field-sample-qty">
+                        <label for="card-sample-qty">Количество образцов</label>
+                        <input id="card-sample-qty" type="number" min="0" step="1" form="card-form" />
+                      </div>
+                      <div class="flex-col product-field hidden" id="field-sample-serials">
+                        <label>Индивидуальные номера образцов</label>
+                        <div id="card-sample-serials-table-wrapper" class="serials-table-wrapper"></div>
+                      </div>
                     </div>
                 </div>
 

--- a/server.js
+++ b/server.js
@@ -810,6 +810,9 @@ async function migrateBarcodesToCode128() {
 function mapCardForPrint(card = {}) {
   const toText = (value) => value == null ? '' : String(value);
   const batchRaw = card.batchSize == null ? card.quantity : card.batchSize;
+  const individualNumbers = Array.isArray(card.itemSerials)
+    ? card.itemSerials.map(v => (v == null ? '' : String(v))).join(', ')
+    : toText(card.itemSerials || '');
   return {
     mkNumber: toText(card.routeCardNumber || card.orderNo || ''),
     docDesignation: toText(card.documentDesignation || card.contractNumber || ''),
@@ -826,7 +829,7 @@ function mapCardForPrint(card = {}) {
     mainMaterialsProcess: toText(card.mainMaterials || ''),
     specialNotes: toText(card.specialNotes || card.desc || ''),
     batchSize: toText(batchRaw == null ? '' : batchRaw),
-    individualNumbers: toText(card.itemSerials || ''),
+    individualNumbers,
     headProduction: toText(card.responsibleProductionChief || ''),
     headSKK: toText(card.responsibleSKKChief || ''),
     zgdTech: toText(card.responsibleTechLead || '')
@@ -1103,12 +1106,15 @@ function buildCardInfoBlockForPrint(card, { startCollapsed = false } = {}) {
     '</div>';
 
   const batchLabel = card.batchSize === '' || card.batchSize == null ? (card.quantity === '' || card.quantity == null ? '—' : toSafeCount(card.quantity)) : card.batchSize;
+  const itemSerials = Array.isArray(card.itemSerials)
+    ? card.itemSerials.map(v => (v == null ? '' : String(v))).join(', ')
+    : (card.itemSerials || '');
   html += '<div class="card-meta-grid card-meta-grid-compact card-display-grid">' +
     '<div class="card-meta-col">' +
     renderCardDisplayField('Размер партии', batchLabel) +
     '</div>' +
     '<div class="card-meta-col">' +
-    renderCardDisplayField('Индивидуальные номера изделий', card.itemSerials || '', { multiline: true }) +
+    renderCardDisplayField('Индивидуальные номера изделий', itemSerials, { multiline: true }) +
     '</div>' +
     '</div>';
 

--- a/style.css
+++ b/style.css
@@ -1115,6 +1115,55 @@ tbody tr:nth-child(even) {
   display: none;
 }
 
+.products-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#tab-products.mki-mode .products-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(260px, 1fr));
+  column-gap: 16px;
+  row-gap: 12px;
+}
+
+#tab-products.mki-mode #field-batch-size,
+#tab-products.mki-mode #field-item-serials {
+  grid-column: 1;
+}
+
+#tab-products.mki-mode #field-sample-qty,
+#tab-products.mki-mode #field-sample-serials {
+  grid-column: 2;
+}
+
+.serials-table-wrapper {
+  width: 100%;
+}
+
+.serials-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 6px;
+}
+
+.serials-table td {
+  padding: 6px 8px;
+  vertical-align: middle;
+}
+
+.serials-index-cell {
+  width: 36px;
+  text-align: right;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+.serials-input-cell input {
+  width: 100%;
+}
+
 .route-add-panel {
   position: sticky;
   bottom: 0;


### PR DESCRIPTION
## Summary
- replace MKI item serial input with dynamic tables tied to batch size and add sample number handling
- enforce MKI validation for batch size and empty serial values during save and print
- keep print output consistent with comma-separated serials while omitting sample data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6947f67b42f88328a8a39f6a22142878)