### PR TITLE
Fix asset paths and SPA routing handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <title>Трекер маршрутных карт ТСЗП</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="style.css" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/style.css" />
 </head>
   <body>
   <div id="login-overlay" class="auth-overlay">
@@ -30,7 +30,7 @@
         <button type="button" id="help-close" class="help-close" aria-label="Закрыть окно инструкции">✕</button>
       </div>
       <div class="help-modal-body">
-        <iframe id="help-frame" src="docs/help.html" title="Инструкция по использованию Трекера маршрутных карт ТСЗП"></iframe>
+        <iframe id="help-frame" src="/docs/help.html" title="Инструкция по использованию Трекера маршрутных карт ТСЗП"></iframe>
       </div>
     </div>
   </div>
@@ -917,8 +917,8 @@
 
   </div>
 
-  <script src="barcodeScanner.js" defer></script>
-  <script src="dashboard.js" defer></script>
-  <script src="app.js" defer></script>
+  <script src="/barcodeScanner.js" defer></script>
+  <script src="/dashboard.js" defer></script>
+  <script src="/app.js" defer></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -388,7 +388,13 @@ function serveStatic(req, res) {
       '.png': 'image/png',
       '.jpg': 'image/jpeg',
       '.jpeg': 'image/jpeg',
-      '.svg': 'image/svg+xml'
+      '.svg': 'image/svg+xml',
+      '.webp': 'image/webp',
+      '.ico': 'image/x-icon',
+      '.woff': 'font/woff',
+      '.woff2': 'font/woff2',
+      '.ttf': 'font/ttf',
+      '.pdf': 'application/pdf'
     }[ext] || 'application/octet-stream';
 
     fs.readFile(pathname, (readErr, data) => {
@@ -1849,7 +1855,9 @@ async function requestHandler(req, res) {
   if (await handleFileRoutes(req, res)) return;
   const parsed = url.parse(req.url);
   const spaRoutes = new Set(['/cards', '/cards/new', '/cards-mki/new', '/directories', '/dashboard', '/workorders', '/archive', '/workspace', '/users', '/accessLevels', '/']);
-  if (spaRoutes.has(parsed.pathname || '')) {
+  const rawPath = parsed.pathname || '';
+  const normalizedPath = rawPath === '/' ? '/' : rawPath.replace(/\/+$/, '') || '/';
+  if (spaRoutes.has(normalizedPath)) {
     const indexPath = path.join(__dirname, 'index.html');
     fs.readFile(indexPath, (err, data) => {
       if (err) {


### PR DESCRIPTION
## Summary
- load all index.html assets using absolute root-based paths
- normalize trailing slashes for SPA routes so deep URLs serve the app consistently
- extend static file MIME types to include webp, ico, font, and pdf formats

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694997dbe9f48328b7f703bc94536b8f)