### PR TITLE
Show SPA page views on dedicated routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ let dashboardStatusSnapshot = null;
 let dashboardEligibleCache = [];
 let workspaceSearchTerm = '';
 let scannerRegistry = {};
-let appState = { tab: 'dashboard', modal: null };
+let appState = { tab: 'dashboard', modal: null, page: null, route: null };
 let restoringState = false;
 let workspaceStopContext = null;
 let workspaceActiveModalInput = null;
@@ -310,11 +310,99 @@ function getDefaultTab() {
   return allowed.includes(forced) ? forced : allowed[0];
 }
 
+const PAGE_ROUTE_MAP = {
+  '/cards/new': { key: 'card-new', cardType: 'MK' },
+  '/cards-mki/new': { key: 'mki-new', cardType: 'MKI' },
+  '/directories': { key: 'directories' }
+};
+
+const PAGE_VIEW_IDS = {
+  'card-new': 'page-card-new',
+  'mki-new': 'page-card-mki-new',
+  'directories': 'page-directories'
+};
+
+const PAGE_MOUNTS = {
+  cardModal: {
+    host: 'card-modal-host',
+    mounts: {
+      'card-new': 'page-card-new-mount',
+      'mki-new': 'page-card-mki-new-mount'
+    }
+  },
+  directoryModal: {
+    host: 'directory-modal-host',
+    mounts: {
+      directories: 'page-directories-mount'
+    }
+  }
+};
+
+function normalizePathname(pathname) {
+  if (!pathname || pathname === '/') return '/';
+  return pathname.replace(/\/+$/g, '') || '/';
+}
+
+function isPageRoute(pathname) {
+  const normalized = normalizePathname(pathname);
+  return Boolean(PAGE_ROUTE_MAP[normalized]);
+}
+
+function moveElementToMount(elementId, mountId) {
+  const el = document.getElementById(elementId);
+  if (!el) return;
+  const target = document.getElementById(mountId);
+  if (target && el.parentElement !== target) {
+    target.appendChild(el);
+  }
+}
+
+function mountModalForPage(pageKey) {
+  const cardModal = PAGE_MOUNTS.cardModal;
+  const directoryModal = PAGE_MOUNTS.directoryModal;
+  if (pageKey === 'card-new' || pageKey === 'mki-new') {
+    const mountId = cardModal.mounts[pageKey] || cardModal.host;
+    moveElementToMount('card-modal', mountId);
+    moveElementToMount('attachments-modal', mountId);
+    return;
+  }
+  if (pageKey === 'directories') {
+    const mountId = directoryModal.mounts[pageKey] || directoryModal.host;
+    moveElementToMount('directory-modal', mountId);
+    return;
+  }
+  moveElementToMount('card-modal', cardModal.host);
+  moveElementToMount('attachments-modal', cardModal.host);
+  moveElementToMount('directory-modal', directoryModal.host);
+}
+
+function togglePageViews(activePageKey = null) {
+  const activeId = activePageKey ? PAGE_VIEW_IDS[activePageKey] : null;
+  document.querySelectorAll('.page-view').forEach(view => {
+    view.classList.toggle('hidden', view.id !== activeId);
+  });
+  document.body.classList.toggle('page-route-active', Boolean(activePageKey));
+}
+
 function updateHistoryState({ replace = false } = {}) {
   if (restoringState) return;
   const method = replace ? 'replaceState' : 'pushState';
   try {
-    const url = appState.route || ('#' + (appState.tab || ''));
+    const isHome = window.location.pathname === '/';
+    const hasHash = !!window.location.hash;
+    const pathWithSearch = window.location.pathname + window.location.search;
+    const currentHash = window.location.hash;
+
+    let url;
+    if (appState.route) {
+      url = hasHash && appState.route === pathWithSearch
+        ? appState.route + currentHash
+        : appState.route;
+    } else if (isHome || hasHash) {
+      url = '#' + (appState.tab || '');
+    } else {
+      url = pathWithSearch;
+    }
     history[method](appState, '', url);
   } catch (err) {
     console.warn('History update failed', err);
@@ -370,8 +458,11 @@ function closeAllModals(silent = false) {
 function closePageScreens() {
   closeCardModal(true);
   closeDirectoryModal(true);
+  togglePageViews(null);
+  mountModalForPage(null);
   document.body.classList.remove('page-card-mode');
   document.body.classList.remove('page-directory-mode');
+  appState = { ...appState, page: null };
 }
 
 function handleRoute(path, { replace = false, fromHistory = false } = {}) {
@@ -382,7 +473,8 @@ function handleRoute(path, { replace = false, fromHistory = false } = {}) {
     urlObj = new URL('/', window.location.origin);
   }
 
-  const basePath = urlObj.pathname || '/';
+  const rawPath = urlObj.pathname || '/';
+  const basePath = normalizePathname(rawPath);
   const search = urlObj.search || '';
   const normalized = (basePath || '/') + search;
   const tabRoutes = {
@@ -394,8 +486,8 @@ function handleRoute(path, { replace = false, fromHistory = false } = {}) {
     '/accessLevels': 'accessLevels'
   };
 
-  const pushState = () => {
-    appState = { ...appState, route: normalized };
+  const pushState = (pageKey = null) => {
+    appState = { ...appState, route: normalized, page: pageKey };
     if (fromHistory) return;
     const method = replace ? 'replaceState' : 'pushState';
     try {
@@ -405,23 +497,22 @@ function handleRoute(path, { replace = false, fromHistory = false } = {}) {
     }
   };
 
-  if (basePath === '/cards/new' || basePath === '/cards-mki/new') {
+  const pageConfig = PAGE_ROUTE_MAP[basePath];
+  if (pageConfig) {
+    const { key, cardType } = pageConfig;
     const cardIdParam = urlObj.searchParams.get('cardId');
     const card = cardIdParam ? cards.find(c => c.id === cardIdParam) : null;
-    const defaultType = basePath === '/cards-mki/new' ? 'MKI' : 'MK';
-    const normalizedType = card && card.cardType === 'MKI' ? 'MKI' : defaultType;
-    closePageScreens();
-    activateTab('cards', { skipHistory: true, fromRestore: fromHistory });
-    openCardModal(card ? card.id : null, { cardType: normalizedType, pageMode: true, fromRestore: fromHistory });
-    pushState();
-    return;
-  }
-
-  if (basePath === '/directories') {
-    closePageScreens();
-    activateTab('cards', { skipHistory: true, fromRestore: fromHistory });
-    openDirectoryModal({ pageMode: true });
-    pushState();
+    const resolvedCardType = card && card.cardType === 'MKI' ? 'MKI' : cardType;
+    closeAllModals(true);
+    togglePageViews(key);
+    mountModalForPage(key);
+    appState = { ...appState, page: key, modal: null };
+    if (key === 'card-new' || key === 'mki-new') {
+      openCardModal(card ? card.id : null, { cardType: resolvedCardType, pageMode: true, fromRestore: fromHistory });
+    } else if (key === 'directories') {
+      openDirectoryModal({ pageMode: true });
+    }
+    pushState(key);
     return;
   }
 
@@ -2351,8 +2442,8 @@ async function restoreSession() {
     updateUserBadge();
     hideAuthOverlay();
     showMainApp();
-    applyNavigationPermissions();
     await bootstrapApp();
+    applyNavigationPermissions();
     resetInactivityTimer();
   } catch (err) {
     showAuthOverlay('Введите пароль для входа');
@@ -2381,8 +2472,22 @@ function applyNavigationPermissions() {
     if (section) section.classList.toggle('hidden', !allowed);
   });
 
-  const selected = getDefaultTab();
-  activateTab(selected, { replaceHistory: true });
+  const isHome = window.location.pathname === '/';
+  const hasHash = !!window.location.hash;
+  const onPageRoute = isPageRoute(window.location.pathname);
+  const currentTab = appState.tab && canViewTab(appState.tab) ? appState.tab : getDefaultTab();
+
+  if (onPageRoute) {
+    const navButtons = document.querySelectorAll('.nav-btn');
+    navButtons.forEach(btn => {
+      const target = btn.getAttribute('data-target');
+      btn.classList.toggle('active', target === 'cards');
+    });
+    return;
+  }
+
+  const replaceHistory = isHome || hasHash;
+  activateTab(currentTab, { replaceHistory });
 }
 
 function restoreState(state) {
@@ -3432,7 +3537,11 @@ function openCardModal(cardId, options = {}) {
   closeImdxImportModal();
   closeImdxMissingModal();
   resetImdxImportState();
-  focusCardsSection();
+  if (pageMode) {
+    highlightNavTarget('cards');
+  } else {
+    focusCardsSection();
+  }
   activeCardOriginalId = cardId || null;
   if (cardId) {
     const card = cards.find(c => c.id === cardId);
@@ -7588,6 +7697,7 @@ function openDirectoryModal(options = {}) {
   renderOpsTable();
   modal.classList.remove('hidden');
   if (pageMode) {
+    highlightNavTarget('cards');
     modal.classList.add('page-mode');
     document.body.classList.add('page-directory-mode');
   } else {
@@ -7633,6 +7743,14 @@ function setupCardsTabs() {
   }
 }
 
+function highlightNavTarget(target) {
+  const navButtons = document.querySelectorAll('.nav-btn');
+  navButtons.forEach(btn => {
+    const btnTarget = btn.getAttribute('data-target');
+    btn.classList.toggle('active', btnTarget === target);
+  });
+}
+
 function focusCardsSection() {
   document.querySelectorAll('main section').forEach(sec => {
     sec.classList.toggle('active', sec.id === 'cards');
@@ -7651,18 +7769,6 @@ function focusWorkspaceSearch() {
     input.focus();
     input.select();
   }
-}
-
-function focusCardsSection() {
-  document.querySelectorAll('main section').forEach(sec => {
-    sec.classList.toggle('active', sec.id === 'cards');
-  });
-  const navButtons = document.querySelectorAll('.nav-btn');
-  navButtons.forEach(btn => {
-    const target = btn.getAttribute('data-target');
-    btn.classList.toggle('active', target === 'cards');
-  });
-  setCardsTab('list');
 }
 
 // === ФОРМЫ ===

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <title>Трекер маршрутных карт ТСЗП</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="style.css" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/style.css" />
 </head>
   <body>
   <div id="login-overlay" class="auth-overlay">
@@ -30,7 +30,7 @@
         <button type="button" id="help-close" class="help-close" aria-label="Закрыть окно инструкции">✕</button>
       </div>
       <div class="help-modal-body">
-        <iframe id="help-frame" src="docs/help.html" title="Инструкция по использованию Трекера маршрутных карт ТСЗП"></iframe>
+        <iframe id="help-frame" src="/docs/help.html" title="Инструкция по использованию Трекера маршрутных карт ТСЗП"></iframe>
       </div>
     </div>
   </div>
@@ -105,6 +105,17 @@
   <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="true"></div>
 
   <main>
+    <div id="page-views" class="page-views">
+      <section id="page-card-new" class="page-view hidden">
+        <div id="page-card-new-mount" class="page-view-mount"></div>
+      </section>
+      <section id="page-card-mki-new" class="page-view hidden">
+        <div id="page-card-mki-new-mount" class="page-view-mount"></div>
+      </section>
+      <section id="page-directories" class="page-view hidden">
+        <div id="page-directories-mount" class="page-view-mount"></div>
+      </section>
+    </div>
     <!-- Дашборд -->
     <section id="dashboard" class="active">
       <div class="card">
@@ -298,6 +309,7 @@
         <div id="access-levels-table" class="table-wrapper"></div>
       </div>
     </section>
+    <div id="card-modal-host">
     <div id="card-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="card-modal-title">
       <div class="modal-content card-modal-content">
         <div class="modal-header">
@@ -536,6 +548,7 @@
         </div>
       </div>
     </div>
+    </div>
   </main>
 
   <footer>
@@ -760,6 +773,7 @@
     </div>
   </div>
 
+  <div id="directory-modal-host">
   <div id="directory-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="directory-title">
     <div class="modal-content directory-modal-content">
       <div class="modal-header" style="display:flex; align-items:center; justify-content:space-between; gap:12px;">
@@ -820,6 +834,7 @@
         </div>
       </div>
     </div>
+  </div>
   </div>
 
   <!-- Модальное окно для штрихкода -->
@@ -917,8 +932,8 @@
 
   </div>
 
-  <script src="barcodeScanner.js" defer></script>
-  <script src="dashboard.js" defer></script>
-  <script src="app.js" defer></script>
+  <script src="/barcodeScanner.js" defer></script>
+  <script src="/dashboard.js" defer></script>
+  <script src="/app.js" defer></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -45,6 +45,8 @@ const DEFAULT_PERMISSIONS = {
 const OPERATION_TYPE_OPTIONS = ['Стандартная', 'Идентификация', 'Документы'];
 const DEFAULT_OPERATION_TYPE = OPERATION_TYPE_OPTIONS[0];
 
+const SPA_ROUTES = new Set(['/cards', '/cards/new', '/cards-mki/new', '/directories', '/dashboard', '/workorders', '/archive', '/workspace', '/users', '/accessLevels', '/']);
+
 const renderMkPrint = buildTemplateRenderer(MK_PRINT_TEMPLATE);
 const renderBarcodeMk = buildTemplateRenderer(BARCODE_MK_TEMPLATE);
 const renderBarcodeGroup = buildTemplateRenderer(BARCODE_GROUP_TEMPLATE);
@@ -388,7 +390,13 @@ function serveStatic(req, res) {
       '.png': 'image/png',
       '.jpg': 'image/jpeg',
       '.jpeg': 'image/jpeg',
-      '.svg': 'image/svg+xml'
+      '.svg': 'image/svg+xml',
+      '.webp': 'image/webp',
+      '.ico': 'image/x-icon',
+      '.woff': 'font/woff',
+      '.woff2': 'font/woff2',
+      '.ttf': 'font/ttf',
+      '.pdf': 'application/pdf'
     }[ext] || 'application/octet-stream';
 
     fs.readFile(pathname, (readErr, data) => {
@@ -1848,8 +1856,14 @@ async function requestHandler(req, res) {
   if (await handleApi(req, res)) return;
   if (await handleFileRoutes(req, res)) return;
   const parsed = url.parse(req.url);
-  const spaRoutes = new Set(['/cards', '/cards/new', '/cards-mki/new', '/directories', '/dashboard', '/workorders', '/archive', '/workspace', '/users', '/accessLevels', '/']);
-  if (spaRoutes.has(parsed.pathname || '')) {
+  const rawPath = parsed.pathname || '';
+  const normalizedPath = rawPath === '/' ? '/' : rawPath.replace(/\/+$/, '') || '/';
+  const isFileRequest = path.posix.basename(normalizedPath).includes('.');
+  if (isFileRequest) {
+    serveStatic(req, res);
+    return;
+  }
+  if (SPA_ROUTES.has(normalizedPath)) {
     const indexPath = path.join(__dirname, 'index.html');
     fs.readFile(indexPath, (err, data) => {
       if (err) {

--- a/style.css
+++ b/style.css
@@ -403,6 +403,18 @@ main {
   margin: 0 auto;
 }
 
+.page-views {
+  display: none;
+}
+
+body.page-route-active .page-views {
+  display: block;
+}
+
+body.page-route-active main > section:not(.page-view) {
+  display: none;
+}
+
 body.page-card-mode main,
 body.page-directory-mode main {
   max-width: none;


### PR DESCRIPTION
## Summary
- ensure SPA page-view container is displayed when page routes are active
- hide legacy tab sections while page routes render their dedicated views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694997dbe9f48328b7f703bc94536b8f)