### PR TITLE
Add SPA page containers for card creation and directories routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,12 @@
 
   <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="true"></div>
 
+  <div id="page-root" class="page-root">
+    <div id="page-cards-new" class="page-view" hidden></div>
+    <div id="page-cards-mki-new" class="page-view" hidden></div>
+    <div id="page-directories" class="page-view" hidden></div>
+  </div>
+
   <main>
     <!-- Дашборд -->
     <section id="dashboard" class="active">


### PR DESCRIPTION
## Summary
- add persistent page containers for card creation and directories pages
- extend routing with page views and allow modals to render into page containers
- adjust navigation permissions and route handling to keep page routes stable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6949bb1d10148328adb61e719f081b2e)