### PR TITLE
Add approvals workflow for route cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
           <a class="nav-dropdown-item" data-route="/cards" href="/cards">Просмотр МК</a>
           <a class="nav-dropdown-item" data-route="/cards/new" href="/cards/new">Создать МК</a>
           <a class="nav-dropdown-item" data-route="/cards-mki/new" href="/cards-mki/new">Создать МКИ</a>
+          <a class="nav-dropdown-item" data-route="/cards/approval" href="/cards/approval">Согласование</a>
           <a class="nav-dropdown-item" data-route="/directories" href="/directories">Справочники</a>
         </div>
       </div>
@@ -152,6 +153,29 @@
           </div>
           <div id="cards-table-wrapper" class="table-wrapper"></div>
         </div>
+      </div>
+    </section>
+
+    <section id="approvals" class="hidden">
+      <div class="card">
+        <h2>Согласование</h2>
+        <div class="flex" style="margin-bottom:8px; align-items:flex-end; flex-wrap:wrap; gap:8px;">
+          <div class="flex-col" style="flex:1 1 320px;">
+            <label for="approvals-search">Поиск (штрихкод Code128, наименование, заказ, договор)</label>
+            <input id="approvals-search" placeholder="Введите штрихкод (Code128) или наименование, номер заказа или договора" />
+          </div>
+          <div class="flex-col" style="flex:0 1 200px;">
+            <label for="approvals-status">Статус согласования</label>
+            <select id="approvals-status">
+              <option value="Не согласовано">Не согласовано</option>
+              <option value="Согласовано">Согласовано</option>
+            </select>
+          </div>
+          <div class="flex-col" style="flex:0 0 auto;">
+            <button class="btn-secondary" id="approvals-search-clear">Сбросить</button>
+          </div>
+        </div>
+        <div id="approvals-table-wrapper" class="table-wrapper"></div>
       </div>
     </section>
 
@@ -586,6 +610,43 @@
       <div class="modal-actions">
         <button type="button" class="btn-secondary" id="delete-confirm-cancel">Отменить</button>
         <button type="button" class="btn-danger" id="delete-confirm-apply">Удалить</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="approval-confirm-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="approval-confirm-title">
+    <div class="modal-content confirm-modal-content">
+      <div class="modal-header">
+        <h3 id="approval-confirm-title">Подтверждение согласования</h3>
+        <button type="button" class="btn-secondary" id="approval-confirm-close" aria-label="Закрыть окно подтверждения">×</button>
+      </div>
+      <div class="modal-body">
+        <p id="approval-confirm-message"></p>
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="btn-secondary" id="approval-confirm-cancel">Отменить</button>
+        <button type="button" class="btn-primary" id="approval-confirm-continue">Продолжить</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="approval-reject-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="approval-reject-title">
+    <div class="modal-content confirm-modal-content">
+      <div class="modal-header">
+        <h3 id="approval-reject-title">Отклонение согласования</h3>
+        <button type="button" class="btn-secondary" id="approval-reject-close" aria-label="Закрыть окно отклонения">×</button>
+      </div>
+      <div class="modal-body">
+        <label for="approval-reject-input">Причина отклонения:</label>
+        <textarea id="approval-reject-input" maxlength="600" rows="4"></textarea>
+        <div class="approval-reject-meta">
+          <span id="approval-reject-error" class="form-error"></span>
+          <span id="approval-reject-count">0/600</span>
+        </div>
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="btn-secondary" id="approval-reject-cancel">Отменить</button>
+        <button type="button" class="btn-danger" id="approval-reject-confirm">Подтвердить отклонение</button>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -2484,6 +2484,68 @@ footer {
   background: #f3f4f6;
 }
 
+.approval-status-cell {
+  text-align: center;
+}
+
+.approval-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.approval-status-approved {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.12);
+}
+
+.approval-status-rejected {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.approval-status-pending {
+  color: #6b7280;
+  background: rgba(107, 114, 128, 0.12);
+}
+
+.approval-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.approval-role-hint {
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.approval-col-icon {
+  text-align: center;
+  width: 56px;
+}
+
+.approval-reject-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 6px;
+}
+
+.muted {
+  color: #6b7280;
+  font-size: 12px;
+}
+
 @media (max-width: 640px) {
   .auth-modal {
     max-width: 92vw;


### PR DESCRIPTION
### Motivation
- Introduce a role-based approvals flow so route cards can be accepted or rejected by production, SKK and tech lead roles before entering production. 
- Store per-role approval status and rejection reasons on cards in the database representation. 
- Prevent unapproved cards from appearing in tracker/workspace/archive and provide a dedicated approval UI for reviewers. 
- Reuse existing tab/permissions model so approvals respect access levels and read/edit rights.

### Description
- Add new approval constants, per-role approval fields (`approvalProductionStatus`, `approvalSKKStatus`, `approvalTechStatus`) and `rejectionReason` to card model and initialization in `app.js` and `server.js`.
- Implement approvals UI: new `Согласование` page, search/status filters, table columns with role icons, and approve/reject buttons that open confirm/reject modals in `index.html`, `app.js` and `style.css`.
- Add modal dialogs and client logic to confirm irreversible approvals, collect up to 600-char rejection reasons, append reasons with `@Username:` and lock buttons after decision, and log actions via existing `recordCardLog` utilities in `app.js`.
- Update status handling and visibility: normalize approval statuses, update `recalcCardStatus`/`getCardProcessState`/renderers to honor approval states and filter out unapproved cards from tracker/workspace/archive, plus read-only card view for approvals.

### Testing
- Started the server with `node server.js` and it booted successfully with migration messages shown (server listening on port 8000). — succeeded.
- Performed a headless UI smoke test that navigated to `/cards/approval` and captured a screenshot to verify the approvals page rendered. — succeeded.
- Rendered the main app pages via `renderEverything()` path to ensure new page and modals are initialized during bootstrap. — succeeded.
- No unit test suite was added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b0232d8988328a549f8349f7b3146)