### PR TITLE
Scope `app.js` to avoid duplicate globals and add approvals UI/logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,13 @@
+(() => {
 // === КОНСТАНТЫ И ГЛОБАЛЬНЫЕ МАССИВЫ ===
+const CARD_STATUS_NOT_APPROVED = 'Не согласовано';
+const CARD_STATUS_APPROVED = 'Согласовано';
+const APPROVAL_STATUSES = [CARD_STATUS_NOT_APPROVED, CARD_STATUS_APPROVED];
+const APPROVAL_ROLES = [
+  { key: 'production', label: 'Начальник производства', icon: '🔨', permission: 'headProduction', field: 'approvalProductionStatus' },
+  { key: 'skk', label: 'Начальник СКК', icon: '🔍', permission: 'headSKK', field: 'approvalSKKStatus' },
+  { key: 'tech', label: 'ЗГД по технологиям', icon: '🧠', permission: 'deputyTechDirector', field: 'approvalTechStatus' }
+];
 const API_ENDPOINT = '/api/data';
 
 let cards = [];
@@ -30,6 +39,8 @@ let activeMkiDraft = null;
 let activeMkiId = null;
 let mkiIsNew = false;
 let cardsSearchTerm = '';
+let approvalSearchTerm = '';
+let approvalStatusFilter = CARD_STATUS_NOT_APPROVED;
 let attachmentContext = null;
 let routeQtyManual = false;
 let imdxImportState = { parsed: null, missing: null };
@@ -51,7 +62,9 @@ let workspaceStopContext = null;
 let workspaceActiveModalInput = null;
 let cardActiveSectionKey = 'main';
 let deleteContext = null;
+let approvalActionContext = null;
 let cardRenderMode = 'modal';
+let cardModalReadonly = false;
 let directoryRenderMode = 'modal';
 let cardPageMount = null;
 let directoryPageMount = null;
@@ -62,6 +75,7 @@ const modalMountRegistry = {
 const ACCESS_TAB_CONFIG = [
   { key: 'dashboard', label: 'Дашборд' },
   { key: 'cards', label: 'МК' },
+  { key: 'approvals', label: 'Согласование' },
   { key: 'workorders', label: 'Трекер' },
   { key: 'archive', label: 'Архив' },
   { key: 'workspace', label: 'Рабочее место' },
@@ -506,6 +520,7 @@ function handleRoute(path, { replace = false, fromHistory = false } = {}) {
   const normalized = (basePath || '/') + search;
   const tabRoutes = {
     '/dashboard': 'dashboard',
+    '/cards/approval': 'approvals',
     '/workorders': 'workorders',
     '/archive': 'archive',
     '/workspace': 'workspace',
@@ -556,6 +571,15 @@ function handleRoute(path, { replace = false, fromHistory = false } = {}) {
   if (basePath === '/cards') {
     closePageScreens();
     activateTab('cards', { skipHistory: true, fromRestore: fromHistory });
+    pushState();
+    return;
+  }
+
+  if (basePath === '/cards/approval' && !canViewTab('approvals')) {
+    alert('Нет прав доступа к разделу');
+    const fallbackTab = getDefaultTab();
+    closePageScreens();
+    activateTab(fallbackTab, { skipHistory: true, fromRestore: fromHistory });
     pushState();
     return;
   }
@@ -685,6 +709,47 @@ function getUserPermissions() {
   return currentUser.permissions;
 }
 
+function isApprovalStatus(value) {
+  return APPROVAL_STATUSES.includes((value || '').toString().trim());
+}
+
+function normalizeApprovalStatus(value) {
+  const normalized = (value || '').toString().trim();
+  if (!normalized || normalized === 'NOT_STARTED' || normalized === 'Не запущена') {
+    return CARD_STATUS_NOT_APPROVED;
+  }
+  return normalized;
+}
+
+function ensureApprovalFields(card) {
+  if (!card) return;
+  card.approvalProductionStatus = isApprovalStatus(card.approvalProductionStatus)
+    ? card.approvalProductionStatus
+    : CARD_STATUS_NOT_APPROVED;
+  card.approvalSKKStatus = isApprovalStatus(card.approvalSKKStatus)
+    ? card.approvalSKKStatus
+    : CARD_STATUS_NOT_APPROVED;
+  card.approvalTechStatus = isApprovalStatus(card.approvalTechStatus)
+    ? card.approvalTechStatus
+    : CARD_STATUS_NOT_APPROVED;
+  card.rejectionReason = typeof card.rejectionReason === 'string' ? card.rejectionReason : '';
+  card.status = normalizeApprovalStatus(card.status);
+}
+
+function getUserApprovalRoles() {
+  const perms = getUserPermissions() || {};
+  return APPROVAL_ROLES.filter(role => perms[role.permission]);
+}
+
+function getPrimaryApprovalRole() {
+  const roles = getUserApprovalRoles();
+  return roles.length ? roles[0] : null;
+}
+
+function hasApprovalDecision(card, field) {
+  return Array.isArray(card?.logs) && card.logs.some(entry => entry.field === field);
+}
+
 function canViewTab(tabKey) {
   const perms = getUserPermissions();
   if (!perms) return true;
@@ -722,12 +787,38 @@ function applyReadonlyState(tabKey, sectionId) {
   });
 }
 
+function applyCardModalReadonly(readonly) {
+  const modal = document.getElementById('card-modal');
+  if (!modal) return;
+  const allowIds = new Set(['card-cancel-btn', 'card-print-btn']);
+  modal.classList.toggle('modal-readonly', readonly);
+  const controls = modal.querySelectorAll('input, select, textarea, button');
+  controls.forEach(ctrl => {
+    if (allowIds.has(ctrl.id)) {
+      ctrl.disabled = false;
+      ctrl.classList.remove('view-disabled');
+      return;
+    }
+    if (readonly) {
+      ctrl.disabled = true;
+      ctrl.classList.add('view-disabled');
+    } else {
+      ctrl.disabled = false;
+      ctrl.classList.remove('view-disabled');
+    }
+  });
+}
+
 function cloneCard(card) {
   return JSON.parse(JSON.stringify(card));
 }
 
 function isGroupCard(card) {
   return Boolean(card && card.isGroup);
+}
+
+function isCardBlockedFromProduction(card) {
+  return card && card.status === CARD_STATUS_NOT_APPROVED;
 }
 
 function getCardBarcodeValue(card) {
@@ -1117,6 +1208,7 @@ function ensureCardMeta(card, options = {}) {
     : '';
   card.responsibleSKKChief = typeof card.responsibleSKKChief === 'string' ? card.responsibleSKKChief : '';
   card.responsibleTechLead = typeof card.responsibleTechLead === 'string' ? card.responsibleTechLead : '';
+  ensureApprovalFields(card);
   card.useItemList = Boolean(card.useItemList);
   if (typeof card.createdAt !== 'number') {
     card.createdAt = Date.now();
@@ -1472,49 +1564,12 @@ function createRouteOpFromRefs(op, center, executor, plannedMinutes, order, opti
 }
 
 function recalcCardStatus(card) {
-  if (isGroupCard(card)) {
-    const children = card.archived ? getGroupChildren(card) : getActiveGroupChildren(card);
-    if (!children.length) {
-      card.status = 'NOT_STARTED';
-      return;
-    }
-    const childStatuses = children.map(c => c.status || 'NOT_STARTED');
-    const allDone = childStatuses.every(s => s === 'DONE');
-    const anyInProgress = childStatuses.some(s => s === 'IN_PROGRESS');
-    const anyPaused = childStatuses.some(s => s === 'PAUSED');
-    const anyDone = childStatuses.some(s => s === 'DONE');
-    const anyNotStarted = childStatuses.some(s => s === 'NOT_STARTED');
-    if (anyInProgress) {
-      card.status = 'IN_PROGRESS';
-    } else if (anyPaused) {
-      card.status = 'PAUSED';
-    } else if (allDone) {
-      card.status = 'DONE';
-    } else if (anyDone && anyNotStarted) {
-      card.status = 'PAUSED';
-    } else {
-      card.status = 'NOT_STARTED';
-    }
+  if (!card || card.status === CARD_STATUS_NOT_APPROVED) return;
+  const state = getCardProcessState(card, { includeArchivedChildren: Boolean(card.archived) });
+  if (card.status === CARD_STATUS_APPROVED && state.key === 'NOT_STARTED') {
     return;
   }
-  const opsArr = card.operations || [];
-  if (!opsArr.length) {
-    card.status = 'NOT_STARTED';
-    return;
-  }
-  const hasActive = opsArr.some(o => o.status === 'IN_PROGRESS' || o.status === 'PAUSED');
-  const allDone = opsArr.length > 0 && opsArr.every(o => o.status === 'DONE');
-  const hasNotStarted = opsArr.some(o => o.status === 'NOT_STARTED' || !o.status);
-  const hasDone = opsArr.some(o => o.status === 'DONE');
-  if (hasActive) {
-    card.status = 'IN_PROGRESS';
-  } else if (hasDone && hasNotStarted) {
-    card.status = 'PAUSED';
-  } else if (allDone && !hasNotStarted) {
-    card.status = 'DONE';
-  } else {
-    card.status = 'NOT_STARTED';
-  }
+  card.status = state.label;
 }
 
 function statusBadge(status) {
@@ -1525,15 +1580,22 @@ function statusBadge(status) {
 }
 
 function cardStatusText(card) {
+  const statusValue = card ? card.status : '';
+  if (statusValue === CARD_STATUS_NOT_APPROVED) return CARD_STATUS_NOT_APPROVED;
   if (isGroupCard(card)) {
     const children = card.archived ? getGroupChildren(card) : getActiveGroupChildren(card);
-    if (!children.length) return 'Не запущена';
-    const anyInProgress = children.some(c => c.status === 'IN_PROGRESS');
-    const anyPaused = children.some(c => c.status === 'PAUSED');
+    if (!children.length) return statusValue === CARD_STATUS_APPROVED ? CARD_STATUS_APPROVED : 'Не запущена';
+    const anyStarted = children.some(ch => (ch.operations || []).some(op =>
+      op.status === 'IN_PROGRESS' || op.status === 'DONE' || op.status === 'PAUSED'
+    ));
+    if (statusValue === CARD_STATUS_APPROVED && !anyStarted) return CARD_STATUS_APPROVED;
+    const childStates = children.map(ch => getCardProcessState(ch, { includeArchivedChildren: card.archived }));
+    const anyInProgress = childStates.some(state => state.key === 'IN_PROGRESS');
+    const anyPaused = childStates.some(state => state.key === 'PAUSED' || state.key === 'MIXED');
     const anyPausedOp = children.some(ch => (ch.operations || []).some(op => op.status === 'PAUSED'));
-    const allDone = children.length > 0 && children.every(c => c.status === 'DONE');
-    const anyDone = children.some(c => c.status === 'DONE');
-    const anyNotStarted = children.some(c => c.status === 'NOT_STARTED' || !c.status);
+    const allDone = childStates.length > 0 && childStates.every(state => state.key === 'DONE');
+    const anyDone = childStates.some(state => state.key === 'DONE');
+    const anyNotStarted = childStates.some(state => state.key === 'NOT_STARTED');
 
     if (anyPausedOp) return 'Смешанно';
     if (anyInProgress) return 'Выполняется';
@@ -1548,6 +1610,7 @@ function cardStatusText(card) {
     o.status === 'IN_PROGRESS' || o.status === 'DONE' || o.status === 'PAUSED'
   );
   if (!opsArr.length || !hasStartedOrDoneOrPaused) {
+    if (statusValue === CARD_STATUS_APPROVED) return CARD_STATUS_APPROVED;
     return 'Не запущена';
   }
 
@@ -1588,11 +1651,13 @@ function cardStatusText(card) {
   return 'Не запущена';
 }
 
-function getCardProcessState(card, { includeArchivedChildren = false } = {}) {
+function getCardProcessState(card, { includeArchivedChildren = false, includeBlockedChildren = false } = {}) {
   if (isGroupCard(card)) {
-    const children = getGroupChildren(card).filter(c => includeArchivedChildren || !c.archived);
+    const children = getGroupChildren(card).filter(c =>
+      (includeArchivedChildren || !c.archived) && (includeBlockedChildren || !isCardBlockedFromProduction(c))
+    );
     if (!children.length) return { key: 'NOT_STARTED', label: 'Не запущено', className: 'not-started' };
-    const childStates = children.map(c => getCardProcessState(c, { includeArchivedChildren }));
+    const childStates = children.map(c => getCardProcessState(c, { includeArchivedChildren, includeBlockedChildren }));
     const hasPausedOp = children.some(ch => (ch.operations || []).some(op => op.status === 'PAUSED'));
     const hasInProgress = childStates.some(s => s.key === 'IN_PROGRESS');
     const hasPaused = childStates.some(s => s.key === 'PAUSED' || s.key === 'MIXED');
@@ -1637,7 +1702,7 @@ function cardHasMissingExecutors(card) {
 
 function groupHasMissingExecutors(group) {
   if (!isGroupCard(group)) return false;
-  const children = getGroupChildren(group).filter(c => !c.archived);
+  const children = getGroupChildren(group).filter(c => !c.archived && !isCardBlockedFromProduction(c));
   return children.some(cardHasMissingExecutors);
 }
 
@@ -2318,7 +2383,11 @@ function ensureDefaults() {
         material: 'Сталь',
         orderNo: 'DEMO-001',
         desc: 'Демонстрационная карта для примера.',
-        status: 'NOT_STARTED',
+        status: CARD_STATUS_NOT_APPROVED,
+        approvalProductionStatus: CARD_STATUS_NOT_APPROVED,
+        approvalSKKStatus: CARD_STATUS_NOT_APPROVED,
+        approvalTechStatus: CARD_STATUS_NOT_APPROVED,
+        rejectionReason: '',
         archived: false,
         attachments: [],
         operations: [
@@ -2566,6 +2635,7 @@ window.addEventListener('popstate', (event) => {
 function syncReadonlyLocks() {
   applyReadonlyState('dashboard', 'dashboard');
   applyReadonlyState('cards', 'cards');
+  applyReadonlyState('approvals', 'approvals');
   applyReadonlyState('workorders', 'workorders');
   applyReadonlyState('archive', 'archive');
   applyReadonlyState('workspace', 'workspace');
@@ -2702,6 +2772,7 @@ async function bootstrapApp() {
     setupForms();
     setupBarcodeModal();
     setupDeleteConfirmModal();
+    setupApprovalModals();
     initScanButton('cards-search', 'cards-scan-btn');
     initScanButton('workorder-search', 'workorder-scan-btn');
     initScanButton('archive-search', 'archive-scan-btn');
@@ -2732,8 +2803,8 @@ function renderDashboard() {
   const statsContainer = document.getElementById('dashboard-stats');
   const activeCards = cards.filter(c => !c.archived && !isGroupCard(c));
   const cardsCount = activeCards.length;
-  const inWork = activeCards.filter(c => c.status === 'IN_PROGRESS').length;
-  const done = activeCards.filter(c => c.status === 'DONE').length;
+  const inWork = activeCards.filter(c => getCardProcessState(c).key === 'IN_PROGRESS').length;
+  const done = activeCards.filter(c => getCardProcessState(c).key === 'DONE').length;
   const notStarted = cardsCount - inWork - done;
 
   statsContainer.innerHTML = '';
@@ -2755,7 +2826,7 @@ function renderDashboard() {
     const map = new Map();
     cards.forEach(card => {
       if (card && !card.archived) {
-        map.set(card.id, card.status || 'NOT_STARTED');
+        map.set(card.id, getCardProcessState(card).key);
       }
     });
     return map;
@@ -2772,7 +2843,7 @@ function renderDashboard() {
 
   dashboardStatusSnapshot = currentStatusSnapshot;
   if (statusChanged) {
-    dashboardEligibleCache = activeCards.filter(c => c.status !== 'NOT_STARTED');
+    dashboardEligibleCache = activeCards.filter(c => getCardProcessState(c).key !== 'NOT_STARTED');
   }
   const eligibleCards = dashboardEligibleCache;
   const emptyMessage = '<p>Карт для отображения пока нет.</p>';
@@ -2802,7 +2873,7 @@ function renderDashboard() {
     let statusHtml = '';
 
     let opsForDisplay = [];
-    if (card.status === 'DONE') {
+    if (getCardProcessState(card).key === 'DONE') {
       statusHtml = '<span class="dash-card-completed">Завершена</span>';
     } else if (!opsArr.length || opsArr.every(o => o.status === 'NOT_STARTED' || !o.status)) {
       statusHtml = 'Не запущена';
@@ -2842,7 +2913,7 @@ function renderDashboard() {
     const { qty: qtyTotal, hasValue: hasQty } = getCardPlannedQuantity(card);
     let qtyCell = '—';
 
-    if (card.status === 'DONE' && hasQty) {
+    if (getCardProcessState(card).key === 'DONE' && hasQty) {
       const batchResult = calculateFinalResults(opsArr, qtyTotal || 0);
       const qtyText = (batchResult.good_final || 0) + ' из ' + qtyTotal;
       qtyCell = '<div class="dash-qty-line">' + qtyText + '</div>';
@@ -2933,7 +3004,7 @@ function renderCardsTable() {
 
   const filteredCards = sortedCards.filter(card => {
     if (isGroupCard(card)) {
-      const children = getGroupChildren(card).filter(c => !c.archived);
+      const children = getGroupChildren(card).filter(c => !c.archived && !isCardBlockedFromProduction(c));
       return cardMatches(card) || children.some(ch => cardMatches(ch));
     }
     return cardMatches(card);
@@ -2950,7 +3021,7 @@ function renderCardsTable() {
 
   filteredCards.forEach(card => {
     if (isGroupCard(card)) {
-      const children = getGroupChildren(card).filter(c => !c.archived);
+      const children = getGroupChildren(card).filter(c => !c.archived && !isCardBlockedFromProduction(c));
       const filesCount = (card.attachments || []).length;
       const opened = cardsGroupOpen.has(card.id);
       const opsTotal = children.reduce((acc, c) => acc + ((c.operations || []).length), 0);
@@ -3083,6 +3154,156 @@ function renderCardsTable() {
   applyReadonlyState('cards', 'cards');
 }
 
+function renderApprovalStatusIcon(status) {
+  if (status === CARD_STATUS_APPROVED) {
+    return '<span class="approval-status approval-status-approved" title="Согласовано">✔</span>';
+  }
+  if (status === CARD_STATUS_NOT_APPROVED) {
+    return '<span class="approval-status approval-status-rejected" title="Не согласовано">✖</span>';
+  }
+  return '<span class="approval-status approval-status-pending" title="Ожидает">—</span>';
+}
+
+function updateCardApprovalStatus(card) {
+  if (!card) return;
+  const allApproved = APPROVAL_ROLES.every(role => card[role.field] === CARD_STATUS_APPROVED);
+  const nextStatus = allApproved ? CARD_STATUS_APPROVED : CARD_STATUS_NOT_APPROVED;
+  if (card.status !== nextStatus) {
+    recordCardLog(card, { action: 'Статус карты', object: 'Карта', field: 'status', oldValue: card.status, newValue: nextStatus });
+    card.status = nextStatus;
+  }
+}
+
+function appendRejectionReason(card, reason) {
+  if (!card) return;
+  const author = currentUser && currentUser.name ? currentUser.name : 'Пользователь';
+  const entry = '@' + author + ': ' + reason;
+  if (card.rejectionReason && card.rejectionReason.trim()) {
+    card.rejectionReason = card.rejectionReason.trim() + '\n' + entry;
+  } else {
+    card.rejectionReason = entry;
+  }
+}
+
+function renderApprovalTable() {
+  const wrapper = document.getElementById('approvals-table-wrapper');
+  if (!wrapper) return;
+  if (!canViewTab('approvals')) {
+    wrapper.innerHTML = '<p>Нет прав для просмотра согласования.</p>';
+    return;
+  }
+  const visibleCards = cards.filter(card => !card.archived && !card.groupId && APPROVAL_STATUSES.includes(card.status));
+  const termRaw = approvalSearchTerm.trim();
+  let filteredCards = visibleCards.filter(card => (termRaw ? cardSearchScore(card, termRaw) > 0 : true));
+  filteredCards = filteredCards.filter(card => card.status === approvalStatusFilter);
+
+  if (!filteredCards.length) {
+    wrapper.innerHTML = '<p>Карты по запросу не найдены.</p>';
+    return;
+  }
+
+  filteredCards.sort((a, b) => cardSearchScore(b, termRaw) - cardSearchScore(a, termRaw));
+
+  let html = '<table><thead><tr>' +
+    '<th>Маршрутная карта № (Code128)</th>' +
+    '<th>Наименование</th>' +
+    '<th>Статус</th>' +
+    '<th>Файлы</th>' +
+    '<th>Печать</th>' +
+    '<th class="approval-col-icon" title="Начальник производства">🔨</th>' +
+    '<th class="approval-col-icon" title="Начальник СКК">🔍</th>' +
+    '<th class="approval-col-icon" title="ЗГД по технологиям">🧠</th>' +
+    '<th>Открыть</th>' +
+    '<th>Согласование</th>' +
+    '</tr></thead><tbody>';
+
+  const primaryRole = getPrimaryApprovalRole();
+  const canEdit = canEditTab('approvals');
+  filteredCards.forEach(card => {
+    const filesCount = (card.attachments || []).length;
+    const barcodeValue = getCardBarcodeValue(card);
+    const statusCell = renderCardStatusCell(card);
+    const decisionLocked = primaryRole ? hasApprovalDecision(card, primaryRole.field) : false;
+    const approveDisabled = !primaryRole || !canEdit || card[primaryRole.field] === CARD_STATUS_APPROVED || decisionLocked;
+    const rejectDisabled = !primaryRole || !canEdit || decisionLocked;
+    const approveAttrs = approveDisabled ? ' disabled' : '';
+    const rejectAttrs = rejectDisabled ? ' disabled' : '';
+    const printButton = '<button class="btn-small" data-action="print-card" data-id="' + card.id + '">Печать</button>';
+    const openButton = '<button class="btn-small" data-action="open-card" data-id="' + card.id + '">Открыть</button>';
+    const approvalButtons = primaryRole
+      ? '<div class="approval-actions">' +
+        '<button class="btn-small btn-primary approval-approve-btn" data-role="' + primaryRole.key + '" data-id="' + card.id + '"' + approveAttrs + '>Согласовать</button>' +
+        '<button class="btn-small btn-secondary approval-reject-btn" data-role="' + primaryRole.key + '" data-id="' + card.id + '"' + rejectAttrs + '>Отклонить</button>' +
+        '</div>' +
+        '<div class="approval-role-hint">Роль: ' + escapeHtml(primaryRole.label) + '</div>'
+      : '<span class="muted">Нет роли согласования</span>';
+
+    html += '<tr>' +
+      '<td><button class="btn-link barcode-link" data-id="' + card.id + '">' + escapeHtml(barcodeValue) + '</button></td>' +
+      '<td>' + escapeHtml(card.name || '') + '</td>' +
+      '<td>' + statusCell + '</td>' +
+      '<td><button class="btn-small clip-btn" data-attach-card="' + card.id + '">📎 <span class="clip-count">' + filesCount + '</span></button></td>' +
+      '<td>' + printButton + '</td>' +
+      '<td class="approval-status-cell">' + renderApprovalStatusIcon(card.approvalProductionStatus) + '</td>' +
+      '<td class="approval-status-cell">' + renderApprovalStatusIcon(card.approvalSKKStatus) + '</td>' +
+      '<td class="approval-status-cell">' + renderApprovalStatusIcon(card.approvalTechStatus) + '</td>' +
+      '<td>' + openButton + '</td>' +
+      '<td>' + approvalButtons + '</td>' +
+      '</tr>';
+  });
+
+  html += '</tbody></table>';
+  wrapper.innerHTML = html;
+
+  wrapper.querySelectorAll('button[data-action="open-card"]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const cardId = btn.getAttribute('data-id');
+      openCardModal(cardId, { readonly: true });
+    });
+  });
+
+  wrapper.querySelectorAll('button[data-action="print-card"]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const card = cards.find(c => c.id === btn.getAttribute('data-id'));
+      if (!card) return;
+      printCardView(card);
+    });
+  });
+
+  wrapper.querySelectorAll('.barcode-link').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-id');
+      const card = cards.find(c => c.id === id);
+      if (!card) return;
+      openBarcodeModal(card);
+    });
+  });
+
+  wrapper.querySelectorAll('button[data-attach-card]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      openAttachmentsModal(btn.getAttribute('data-attach-card'), 'live');
+    });
+  });
+
+  wrapper.querySelectorAll('.approval-approve-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const cardId = btn.getAttribute('data-id');
+      const roleKey = btn.getAttribute('data-role');
+      openApprovalConfirmModal(cardId, roleKey);
+    });
+  });
+
+  wrapper.querySelectorAll('.approval-reject-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const cardId = btn.getAttribute('data-id');
+      const roleKey = btn.getAttribute('data-role');
+      openApprovalRejectModal(cardId, roleKey);
+    });
+  });
+
+  applyReadonlyState('approvals', 'approvals');
+}
+
 function buildCardCopy(template, { nameOverride, groupId = null } = {}) {
   const copy = cloneCard(template);
   copy.id = genId('card');
@@ -3091,7 +3312,11 @@ function buildCardCopy(template, { nameOverride, groupId = null } = {}) {
   copy.name = copy.itemName || 'Маршрутная карта';
   copy.groupId = groupId;
   copy.isGroup = false;
-  copy.status = 'NOT_STARTED';
+  copy.status = CARD_STATUS_NOT_APPROVED;
+  copy.approvalProductionStatus = CARD_STATUS_NOT_APPROVED;
+  copy.approvalSKKStatus = CARD_STATUS_NOT_APPROVED;
+  copy.approvalTechStatus = CARD_STATUS_NOT_APPROVED;
+  copy.rejectionReason = '';
   copy.archived = false;
   copy.useItemList = Boolean(template.useItemList);
   copy.logs = [];
@@ -3296,6 +3521,68 @@ function confirmDeletion() {
   }
 }
 
+function openApprovalConfirmModal(cardId, roleKey) {
+  const modal = document.getElementById('approval-confirm-modal');
+  const messageEl = document.getElementById('approval-confirm-message');
+  if (!modal || !messageEl) return;
+  const role = APPROVAL_ROLES.find(r => r.key === roleKey);
+  if (!cardId || !role) return;
+  approvalActionContext = { cardId, roleKey };
+  messageEl.textContent = 'Согласование нельзя отменить! Продолжить?';
+  modal.classList.remove('hidden');
+}
+
+function closeApprovalConfirmModal() {
+  const modal = document.getElementById('approval-confirm-modal');
+  approvalActionContext = null;
+  if (modal) modal.classList.add('hidden');
+}
+
+function openApprovalRejectModal(cardId, roleKey) {
+  const modal = document.getElementById('approval-reject-modal');
+  const input = document.getElementById('approval-reject-input');
+  const counter = document.getElementById('approval-reject-count');
+  const errorEl = document.getElementById('approval-reject-error');
+  if (!modal || !input || !counter) return;
+  const role = APPROVAL_ROLES.find(r => r.key === roleKey);
+  if (!cardId || !role) return;
+  approvalActionContext = { cardId, roleKey };
+  input.value = '';
+  counter.textContent = '0/600';
+  if (errorEl) errorEl.textContent = '';
+  modal.classList.remove('hidden');
+  input.focus();
+}
+
+function closeApprovalRejectModal() {
+  const modal = document.getElementById('approval-reject-modal');
+  approvalActionContext = null;
+  if (modal) modal.classList.add('hidden');
+}
+
+function applyApprovalDecision({ cardId, roleKey, reason }) {
+  const card = cards.find(c => c.id === cardId);
+  const role = APPROVAL_ROLES.find(r => r.key === roleKey);
+  if (!card || !role) return;
+  if (hasApprovalDecision(card, role.field)) return;
+  const prevStatus = card[role.field];
+  const nextStatus = reason ? CARD_STATUS_NOT_APPROVED : CARD_STATUS_APPROVED;
+  card[role.field] = nextStatus;
+  if (reason) {
+    appendRejectionReason(card, reason);
+  }
+  recordCardLog(card, {
+    action: reason ? 'Отклонение' : 'Согласование',
+    object: role.label,
+    field: role.field,
+    oldValue: prevStatus || '',
+    newValue: nextStatus
+  });
+  updateCardApprovalStatus(card);
+  saveData();
+  renderEverything();
+}
+
 function printGroupList(groupId) {
   const group = cards.find(c => c.id === groupId && isGroupCard(c));
   if (!group) return;
@@ -3386,7 +3673,11 @@ function createGroupFromDraft() {
     orderNo: activeCardDraft.orderNo || '',
     contractNumber: activeCardDraft.contractNumber || '',
     cardType: activeCardDraft.cardType === 'MKI' ? 'MKI' : 'MK',
-    status: 'NOT_STARTED',
+    status: CARD_STATUS_NOT_APPROVED,
+    approvalProductionStatus: CARD_STATUS_NOT_APPROVED,
+    approvalSKKStatus: CARD_STATUS_NOT_APPROVED,
+    approvalTechStatus: CARD_STATUS_NOT_APPROVED,
+    rejectionReason: '',
     archived: false,
     attachments: [],
     createdAt: Date.now()
@@ -3445,7 +3736,11 @@ function createEmptyCardDraft(cardType = 'MK') {
     responsibleProductionChief: '',
     responsibleSKKChief: '',
     responsibleTechLead: '',
-    status: 'NOT_STARTED',
+    status: CARD_STATUS_NOT_APPROVED,
+    approvalProductionStatus: CARD_STATUS_NOT_APPROVED,
+    approvalSKKStatus: CARD_STATUS_NOT_APPROVED,
+    approvalTechStatus: CARD_STATUS_NOT_APPROVED,
+    rejectionReason: '',
     archived: false,
     createdAt: Date.now(),
     logs: [],
@@ -3554,9 +3849,10 @@ function setupCardSectionMenu() {
 }
 
 function openCardModal(cardId, options = {}) {
-  const { fromRestore = false, cardType = 'MK', pageMode = false, renderMode, mountEl = null } = options;
+  const { fromRestore = false, cardType = 'MK', pageMode = false, renderMode, mountEl = null, readonly = false } = options;
   const modal = document.getElementById('card-modal');
   if (!modal) return;
+  cardModalReadonly = Boolean(readonly);
   const mode = renderMode || (pageMode ? 'page' : 'modal');
   cardRenderMode = mode;
   cardPageMount = mode === 'page' ? mountEl : null;
@@ -3591,9 +3887,8 @@ function openCardModal(cardId, options = {}) {
     }
   }
   const cardTypeLabel = activeCardDraft.cardType === 'MKI' ? 'МКИ' : 'МК';
-  document.getElementById('card-modal-title').textContent = activeCardIsNew
-    ? 'Создание ' + cardTypeLabel
-    : 'Редактирование ' + cardTypeLabel;
+  const titlePrefix = readonly ? 'Просмотр' : (activeCardIsNew ? 'Создание' : 'Редактирование');
+  document.getElementById('card-modal-title').textContent = titlePrefix + ' ' + cardTypeLabel;
   document.getElementById('card-id').value = activeCardDraft.id;
   document.getElementById('card-route-number').value = activeCardDraft.routeCardNumber || '';
   document.getElementById('card-document-designation').value = activeCardDraft.documentDesignation || '';
@@ -3680,6 +3975,7 @@ function openCardModal(cardId, options = {}) {
     window.scrollTo({ top: 0, behavior: 'smooth' });
     setModalState({ type: 'card', cardId: activeCardDraft ? activeCardDraft.id : null }, { fromRestore });
   }
+  applyCardModalReadonly(cardModalReadonly);
 }
 
 function closeCardModal(silent = false) {
@@ -3699,6 +3995,7 @@ function closeCardModal(silent = false) {
   activeCardDraft = null;
   activeCardOriginalId = null;
   activeCardIsNew = false;
+  cardModalReadonly = false;
   routeQtyManual = false;
   focusCardsSection();
   restoreModalToHome(modal, 'card');
@@ -5484,7 +5781,7 @@ function buildWorkorderCardDetails(card, { opened = false, allowArchive = true, 
   const missingBadge = cardHasMissingExecutors(card)
     ? '<span class="status-pill status-pill-missing-executor" title="Есть операции без исполнителя">Нет исполнителя</span>'
     : '';
-  const canArchive = allowArchive && card.status === 'DONE' && !readonly;
+  const canArchive = allowArchive && getCardProcessState(card).key === 'DONE' && !readonly;
   const filesCount = (card.attachments || []).length;
   const contractText = card.contractNumber ? ' (Договор: ' + escapeHtml(card.contractNumber) + ')' : '';
   const barcodeButton = ' <button type="button" class="btn-small btn-secondary barcode-view-btn" data-allow-view="true" data-card-id="' + card.id + '" title="Показать штрихкод" aria-label="Показать штрихкод">Штрихкод</button>';
@@ -6679,10 +6976,10 @@ function bindOperationControls(root, { readonly = false } = {}) {
 function renderWorkordersTable({ collapseAll = false } = {}) {
   const wrapper = document.getElementById('workorders-table-wrapper');
   const readonly = isTabReadonly('workorders');
-  const rootCards = cards.filter(c => !c.archived && !c.groupId);
+  const rootCards = cards.filter(c => !c.archived && !c.groupId && !isCardBlockedFromProduction(c));
   const hasOperations = rootCards.some(card => {
     if (isGroupCard(card)) {
-      return getGroupChildren(card).some(ch => !ch.archived && ch.operations && ch.operations.length);
+      return getGroupChildren(card).some(ch => !ch.archived && !isCardBlockedFromProduction(ch) && ch.operations && ch.operations.length);
     }
     return card.operations && card.operations.length;
   });
@@ -6731,7 +7028,8 @@ function renderWorkordersTable({ collapseAll = false } = {}) {
   let html = '';
   filteredBySearch.forEach(card => {
     if (isGroupCard(card)) {
-      const children = getGroupChildren(card).filter(c => !c.archived);
+      const children = getGroupChildren(card).filter(c => !c.archived && !isCardBlockedFromProduction(c));
+      if (!children.length) return;
       const groupMatches = !hasTerm || cardSearchScore(card, termRaw) > 0;
       const matchingChildren = hasTerm ? children.filter(ch => cardSearchScore(ch, termRaw) > 0) : children;
       if (!groupMatches && !matchingChildren.length) return;
@@ -6773,7 +7071,9 @@ function renderWorkordersTable({ collapseAll = false } = {}) {
         '</div>' +
         '<div class="summary-actions group-summary-actions">' +
         statusRow +
-        (!readonly && card.status === 'DONE' ? ' <button type="button" class="btn-small btn-secondary archive-group-btn" data-group-id="' + card.id + '">Перенести в архив</button>' : '') +
+        (!readonly && getCardProcessState(card).key === 'DONE'
+          ? ' <button type="button" class="btn-small btn-secondary archive-group-btn" data-group-id="' + card.id + '">Перенести в архив</button>'
+          : '') +
         '</div>' +
         '</div>' +
         '</summary>' +
@@ -7185,7 +7485,7 @@ function renderWorkordersTable({ collapseAll = false } = {}) {
   const termRaw = workspaceSearchTerm.trim();
   const barcodeTerm = termRaw.trim().toLowerCase();
   const isWorker = currentUser && currentUser.permissions && currentUser.permissions.worker;
-  const activeCards = cards.filter(card => !card.archived && card.operations && card.operations.length);
+  const activeCards = cards.filter(card => !card.archived && !isCardBlockedFromProduction(card) && card.operations && card.operations.length);
   let candidates = [];
   if (!barcodeTerm) {
     if (isWorker && currentUser) {
@@ -7425,7 +7725,7 @@ function buildArchiveGroupDetails(group) {
     ? ' • № карты: <span class="summary-barcode">' + escapeHtml(barcodeValue) + ' <button type="button" class="btn-small btn-secondary wo-barcode-btn" data-card-id="' + group.id + '">Штрихкод</button></span>'
     : '';
   const filesButton = ' <button type="button" class="btn-small clip-btn inline-clip" data-attach-card="' + group.id + '">📎 <span class="clip-count">' + filesCount + '</span></button>';
-  const children = getGroupChildren(group).filter(c => c.archived);
+  const children = getGroupChildren(group).filter(c => c.archived && !isCardBlockedFromProduction(c));
   const childrenHtml = children.length
     ? children.map(child => buildArchiveCardDetails(child, { opened: false })).join('')
     : '<p class="group-empty">В группе нет карт для отображения.</p>';
@@ -7453,8 +7753,10 @@ function buildArchiveGroupDetails(group) {
 
 function renderArchiveTable() {
   const wrapper = document.getElementById('archive-table-wrapper');
-  const archivedCards = cards.filter(c => c.archived && !c.groupId);
-  const groupsWithArchivedChildren = cards.filter(c => isGroupCard(c) && getGroupChildren(c).some(ch => ch.archived));
+  const archivedCards = cards.filter(c => c.archived && !c.groupId && !isCardBlockedFromProduction(c));
+  const groupsWithArchivedChildren = cards.filter(c =>
+    isGroupCard(c) && getGroupChildren(c).some(ch => ch.archived && !isCardBlockedFromProduction(ch))
+  );
 
   const archiveEntries = [...archivedCards];
   groupsWithArchivedChildren.forEach(group => {
@@ -7681,6 +7983,11 @@ function setupCardsDropdownMenu() {
 
     event.preventDefault();
     const route = event.currentTarget.getAttribute('data-route');
+    if (route === '/cards/approval' && !canViewTab('approvals')) {
+      alert('Нет прав доступа к разделу');
+      closeMenu();
+      return;
+    }
     closeMenu();
     if (route) navigateToRoute(route);
     if (window.innerWidth <= 768) closePrimaryNav();
@@ -7729,6 +8036,8 @@ function activateTab(target, options = {}) {
 
   if (target === 'workorders') {
     renderWorkordersTable({ collapseAll: true });
+  } else if (target === 'approvals') {
+    renderApprovalTable();
   } else if (target === 'archive') {
     renderArchiveTable();
   } else if (target === 'workspace') {
@@ -8321,6 +8630,31 @@ function setupForms() {
     });
   }
 
+  const approvalSearchInput = document.getElementById('approvals-search');
+  const approvalSearchClear = document.getElementById('approvals-search-clear');
+  const approvalStatusSelect = document.getElementById('approvals-status');
+  if (approvalSearchInput) {
+    approvalSearchInput.addEventListener('input', e => {
+      approvalSearchTerm = e.target.value || '';
+      renderApprovalTable();
+    });
+  }
+  if (approvalStatusSelect) {
+    approvalStatusSelect.addEventListener('change', e => {
+      approvalStatusFilter = e.target.value || CARD_STATUS_NOT_APPROVED;
+      renderApprovalTable();
+    });
+  }
+  if (approvalSearchClear) {
+    approvalSearchClear.addEventListener('click', () => {
+      approvalSearchTerm = '';
+      approvalStatusFilter = CARD_STATUS_NOT_APPROVED;
+      if (approvalSearchInput) approvalSearchInput.value = '';
+      if (approvalStatusSelect) approvalStatusSelect.value = CARD_STATUS_NOT_APPROVED;
+      renderApprovalTable();
+    });
+  }
+
   const workorderAutoscrollCheckbox = document.getElementById('workorder-autoscroll');
   if (workorderAutoscrollCheckbox) {
     workorderAutoscrollCheckbox.checked = workorderAutoScrollEnabled;
@@ -8441,6 +8775,7 @@ function renderEverything() {
   refreshCardStatuses();
   renderDashboard();
   renderCardsTable();
+  renderApprovalTable();
   renderCentersTable();
   renderOpsTable();
   fillRouteSelectors();
@@ -8473,6 +8808,65 @@ function setupDeleteConfirmModal() {
   }
   if (confirmBtn) {
     confirmBtn.addEventListener('click', () => confirmDeletion());
+  }
+}
+
+function setupApprovalModals() {
+  const confirmModal = document.getElementById('approval-confirm-modal');
+  const confirmCancel = document.getElementById('approval-confirm-cancel');
+  const confirmClose = document.getElementById('approval-confirm-close');
+  const confirmContinue = document.getElementById('approval-confirm-continue');
+
+  if (confirmCancel) confirmCancel.addEventListener('click', () => closeApprovalConfirmModal());
+  if (confirmClose) confirmClose.addEventListener('click', () => closeApprovalConfirmModal());
+  if (confirmModal) {
+    confirmModal.addEventListener('click', (event) => {
+      if (event.target === confirmModal) closeApprovalConfirmModal();
+    });
+  }
+  if (confirmContinue) {
+    confirmContinue.addEventListener('click', () => {
+      if (!approvalActionContext) return;
+      const context = approvalActionContext;
+      closeApprovalConfirmModal();
+      applyApprovalDecision({ cardId: context.cardId, roleKey: context.roleKey });
+    });
+  }
+
+  const rejectModal = document.getElementById('approval-reject-modal');
+  const rejectCancel = document.getElementById('approval-reject-cancel');
+  const rejectClose = document.getElementById('approval-reject-close');
+  const rejectConfirm = document.getElementById('approval-reject-confirm');
+  const rejectInput = document.getElementById('approval-reject-input');
+  const rejectCount = document.getElementById('approval-reject-count');
+  const rejectError = document.getElementById('approval-reject-error');
+
+  if (rejectInput && rejectCount) {
+    rejectInput.addEventListener('input', () => {
+      const len = rejectInput.value.length;
+      rejectCount.textContent = len + '/600';
+    });
+  }
+  if (rejectCancel) rejectCancel.addEventListener('click', () => closeApprovalRejectModal());
+  if (rejectClose) rejectClose.addEventListener('click', () => closeApprovalRejectModal());
+  if (rejectModal) {
+    rejectModal.addEventListener('click', (event) => {
+      if (event.target === rejectModal) closeApprovalRejectModal();
+    });
+  }
+  if (rejectConfirm) {
+    rejectConfirm.addEventListener('click', () => {
+      if (!approvalActionContext) return;
+      const reason = rejectInput ? rejectInput.value.trim() : '';
+      if (!reason) {
+        if (rejectError) rejectError.textContent = 'Укажите причину отклонения.';
+        return;
+      }
+      if (rejectError) rejectError.textContent = '';
+      const context = approvalActionContext;
+      closeApprovalRejectModal();
+      applyApprovalDecision({ cardId: context.cardId, roleKey: context.roleKey, reason });
+    });
   }
 }
 
@@ -8851,3 +9245,4 @@ document.addEventListener('DOMContentLoaded', async () => {
   showSessionOverlay('Проверка сессии...');
   await restoreSession();
 });
+})();

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
           <a class="nav-dropdown-item" data-route="/cards" href="/cards">Просмотр МК</a>
           <a class="nav-dropdown-item" data-route="/cards/new" href="/cards/new">Создать МК</a>
           <a class="nav-dropdown-item" data-route="/cards-mki/new" href="/cards-mki/new">Создать МКИ</a>
+          <a class="nav-dropdown-item" data-route="/cards/approval" href="/cards/approval">Согласование</a>
           <a class="nav-dropdown-item" data-route="/directories" href="/directories">Справочники</a>
         </div>
       </div>
@@ -152,6 +153,29 @@
           </div>
           <div id="cards-table-wrapper" class="table-wrapper"></div>
         </div>
+      </div>
+    </section>
+
+    <section id="approvals" class="hidden">
+      <div class="card">
+        <h2>Согласование</h2>
+        <div class="flex" style="margin-bottom:8px; align-items:flex-end; flex-wrap:wrap; gap:8px;">
+          <div class="flex-col" style="flex:1 1 320px;">
+            <label for="approvals-search">Поиск (штрихкод Code128, наименование, заказ, договор)</label>
+            <input id="approvals-search" placeholder="Введите штрихкод (Code128) или наименование, номер заказа или договора" />
+          </div>
+          <div class="flex-col" style="flex:0 1 200px;">
+            <label for="approvals-status">Статус согласования</label>
+            <select id="approvals-status">
+              <option value="Не согласовано">Не согласовано</option>
+              <option value="Согласовано">Согласовано</option>
+            </select>
+          </div>
+          <div class="flex-col" style="flex:0 0 auto;">
+            <button class="btn-secondary" id="approvals-search-clear">Сбросить</button>
+          </div>
+        </div>
+        <div id="approvals-table-wrapper" class="table-wrapper"></div>
       </div>
     </section>
 
@@ -586,6 +610,43 @@
       <div class="modal-actions">
         <button type="button" class="btn-secondary" id="delete-confirm-cancel">Отменить</button>
         <button type="button" class="btn-danger" id="delete-confirm-apply">Удалить</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="approval-confirm-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="approval-confirm-title">
+    <div class="modal-content confirm-modal-content">
+      <div class="modal-header">
+        <h3 id="approval-confirm-title">Подтверждение согласования</h3>
+        <button type="button" class="btn-secondary" id="approval-confirm-close" aria-label="Закрыть окно подтверждения">×</button>
+      </div>
+      <div class="modal-body">
+        <p id="approval-confirm-message"></p>
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="btn-secondary" id="approval-confirm-cancel">Отменить</button>
+        <button type="button" class="btn-primary" id="approval-confirm-continue">Продолжить</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="approval-reject-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="approval-reject-title">
+    <div class="modal-content confirm-modal-content">
+      <div class="modal-header">
+        <h3 id="approval-reject-title">Отклонение согласования</h3>
+        <button type="button" class="btn-secondary" id="approval-reject-close" aria-label="Закрыть окно отклонения">×</button>
+      </div>
+      <div class="modal-body">
+        <label for="approval-reject-input">Причина отклонения:</label>
+        <textarea id="approval-reject-input" maxlength="600" rows="4"></textarea>
+        <div class="approval-reject-meta">
+          <span id="approval-reject-error" class="form-error"></span>
+          <span id="approval-reject-count">0/600</span>
+        </div>
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="btn-secondary" id="approval-reject-cancel">Отменить</button>
+        <button type="button" class="btn-danger" id="approval-reject-confirm">Подтвердить отклонение</button>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -2484,6 +2484,68 @@ footer {
   background: #f3f4f6;
 }
 
+.approval-status-cell {
+  text-align: center;
+}
+
+.approval-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.approval-status-approved {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.12);
+}
+
+.approval-status-rejected {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.approval-status-pending {
+  color: #6b7280;
+  background: rgba(107, 114, 128, 0.12);
+}
+
+.approval-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.approval-role-hint {
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.approval-col-icon {
+  text-align: center;
+  width: 56px;
+}
+
+.approval-reject-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 6px;
+}
+
+.muted {
+  color: #6b7280;
+  font-size: 12px;
+}
+
 @media (max-width: 640px) {
   .auth-modal {
     max-width: 92vw;


### PR DESCRIPTION
### Motivation
- Prevent runtime errors from duplicate `const` declarations when `app.js` is loaded more than once by scoping the script into an IIFE. 
- Introduce an approvals workflow so cards can be reviewed and either `Согласовано` or `Не согласовано` by specific roles. 
- Ensure approval state is normalized and persisted, and that unapproved cards are blocked from production views and operations. 
- Add UI, routing and permission support so approvals integrate with the SPA navigation and user permissions.

### Description
- Wrapped the entire `app.js` in an IIFE to avoid polluting the global scope and prevent duplicate declaration errors for constants like `CARD_STATUS_NOT_APPROVED`. 
- Added approval-related constants and metadata (`CARD_STATUS_NOT_APPROVED`, `CARD_STATUS_APPROVED`, `APPROVAL_STATUSES`, `APPROVAL_ROLES`) and implemented approval utilities in `app.js` such as `isApprovalStatus`, `normalizeApprovalStatus`, `ensureApprovalFields`, `updateCardApprovalStatus`, `applyApprovalDecision`, and UI rendering functions including `renderApprovalTable`. 
- Integrated approvals into the UI and routing by adding a new navigation item and `approvals` section and modals in `index.html`, approval modal wiring in `app.js` (`setupApprovalModals`, modal open/close handlers), and styles in `style.css` for approval indicators. 
- Updated server-side handling in `server.js` to include approval constants, SPA route `/cards/approval`, default permissions for `approvals`, and normalization of approval fields when loading/saving data.

### Testing
- Performed repository searches with `rg` to confirm `app.js` is included only once in `index.html` and to locate approval-related identifiers, and these checks succeeded. 
- Applied the patch with the repository patch tool and the change was staged and committed with `git commit` successfully. 
- Confirmed `app.js` was updated (IIFE wrap) and new approval UI elements were added to `index.html` and styles to `style.css` via the applied diff, and these file updates applied without errors. 
- No automated unit or integration test suites or server start were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b0232d8988328a549f8349f7b3146)