### PR TITLE
Add read-only responsible fields with approval timestamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,24 +479,30 @@
                     <div class="flex-col card-meta-responsible">
                         <label>Ответственные лица (ФИО)</label>
                         <div class="card-meta-grid card-meta-grid-compact">
-                          <div class="card-meta-col">
-                            <div class="flex-col">
-                              <label for="card-production-chief">Начальник производства (ФИО)</label>
-                              <input id="card-production-chief" form="card-form" />
+                            <div class="card-meta-col">
+                              <div class="flex-col">
+                                <label for="card-production-chief">Начальник производства (ФИО)</label>
+                              <input id="card-production-chief" form="card-form" readonly />
+                              <label for="card-production-chief-at">Дата и время</label>
+                              <input id="card-production-chief-at" form="card-form" readonly />
+                              </div>
                             </div>
-                          </div>
-                          <div class="card-meta-col">
-                            <div class="flex-col">
-                              <label for="card-skk-chief">Начальник СКК (ФИО)</label>
-                              <input id="card-skk-chief" form="card-form" />
+                            <div class="card-meta-col">
+                              <div class="flex-col">
+                                <label for="card-skk-chief">Начальник СКК (ФИО)</label>
+                              <input id="card-skk-chief" form="card-form" readonly />
+                              <label for="card-skk-chief-at">Дата и время</label>
+                              <input id="card-skk-chief-at" form="card-form" readonly />
+                              </div>
                             </div>
-                          </div>
-                          <div class="card-meta-col">
-                            <div class="flex-col">
-                              <label for="card-tech-lead">ЗГД по технологиям (ФИО)</label>
-                              <input id="card-tech-lead" form="card-form" />
+                            <div class="card-meta-col">
+                              <div class="flex-col">
+                                <label for="card-tech-lead">ЗГД по технологиям (ФИО)</label>
+                              <input id="card-tech-lead" form="card-form" readonly />
+                              <label for="card-tech-lead-at">Дата и время</label>
+                              <input id="card-tech-lead-at" form="card-form" readonly />
+                              </div>
                             </div>
-                          </div>
                         </div>
                     </div>
                 </div>

--- a/js/app.10.utils.js
+++ b/js/app.10.utils.js
@@ -573,6 +573,9 @@ function ensureCardMeta(card, options = {}) {
     : '';
   card.responsibleSKKChief = typeof card.responsibleSKKChief === 'string' ? card.responsibleSKKChief : '';
   card.responsibleTechLead = typeof card.responsibleTechLead === 'string' ? card.responsibleTechLead : '';
+  card.responsibleProductionChiefAt = typeof card.responsibleProductionChiefAt === 'number' ? card.responsibleProductionChiefAt : null;
+  card.responsibleSKKChiefAt = typeof card.responsibleSKKChiefAt === 'number' ? card.responsibleSKKChiefAt : null;
+  card.responsibleTechLeadAt = typeof card.responsibleTechLeadAt === 'number' ? card.responsibleTechLeadAt : null;
   card.useItemList = Boolean(card.useItemList);
   if (card.approvalSkkStatus != null && card.approvalSKKStatus == null) {
     card.approvalSKKStatus = card.approvalSkkStatus;

--- a/js/app.70.render.cards.js
+++ b/js/app.70.render.cards.js
@@ -713,8 +713,11 @@ function createEmptyCardDraft(cardType = 'MK') {
     orderNo: '',
     desc: '',
     responsibleProductionChief: '',
+    responsibleProductionChiefAt: null,
     responsibleSKKChief: '',
+    responsibleSKKChiefAt: null,
     responsibleTechLead: '',
+    responsibleTechLeadAt: null,
     status: 'NOT_STARTED',
     approvalStage: APPROVAL_STAGE_DRAFT,
     approvalProductionStatus: null,
@@ -920,6 +923,12 @@ function openCardModal(cardId, options = {}) {
   document.getElementById('card-production-chief').value = activeCardDraft.responsibleProductionChief || '';
   document.getElementById('card-skk-chief').value = activeCardDraft.responsibleSKKChief || '';
   document.getElementById('card-tech-lead').value = activeCardDraft.responsibleTechLead || '';
+  const prodAt = document.getElementById('card-production-chief-at');
+  if (prodAt) prodAt.value = activeCardDraft.responsibleProductionChiefAt ? new Date(activeCardDraft.responsibleProductionChiefAt).toLocaleString() : '';
+  const skkAt = document.getElementById('card-skk-chief-at');
+  if (skkAt) skkAt.value = activeCardDraft.responsibleSKKChiefAt ? new Date(activeCardDraft.responsibleSKKChiefAt).toLocaleString() : '';
+  const techAt = document.getElementById('card-tech-lead-at');
+  if (techAt) techAt.value = activeCardDraft.responsibleTechLeadAt ? new Date(activeCardDraft.responsibleTechLeadAt).toLocaleString() : '';
   const useItemsCheckbox = document.getElementById('card-use-items');
   if (useItemsCheckbox) {
     useItemsCheckbox.checked = Boolean(activeCardDraft.useItemList);
@@ -1141,9 +1150,6 @@ function syncCardDraftFromForm() {
   }
   activeCardDraft.specialNotes = document.getElementById('card-desc').value.trim();
   activeCardDraft.desc = activeCardDraft.specialNotes;
-  activeCardDraft.responsibleProductionChief = document.getElementById('card-production-chief').value.trim();
-  activeCardDraft.responsibleSKKChief = document.getElementById('card-skk-chief').value.trim();
-  activeCardDraft.responsibleTechLead = document.getElementById('card-tech-lead').value.trim();
   const useItemsCheckbox = document.getElementById('card-use-items');
   const prevUseList = Boolean(activeCardDraft.useItemList);
   activeCardDraft.useItemList = useItemsCheckbox ? useItemsCheckbox.checked : false;

--- a/js/app.74.approvals.js
+++ b/js/app.74.approvals.js
@@ -23,6 +23,12 @@ const APPROVAL_ROLE_CONFIG = [
   }
 ];
 
+const APPROVAL_RESPONSIBLE_MAP = {
+  production: { nameField: 'responsibleProductionChief', atField: 'responsibleProductionChiefAt' },
+  skk: { nameField: 'responsibleSKKChief', atField: 'responsibleSKKChiefAt' },
+  tech: { nameField: 'responsibleTechLead', atField: 'responsibleTechLeadAt' }
+};
+
 let approvalRejectContext = null;
 let approvalApproveContext = null;
 
@@ -152,6 +158,16 @@ function confirmApprovalApprove() {
     const oldValue = card[role.statusField];
     card[role.statusField] = APPROVAL_STATUS_APPROVED;
     recordCardLog(card, { action: 'approval', field: role.statusField, oldValue, newValue: card[role.statusField] });
+    const responsibleMap = APPROVAL_RESPONSIBLE_MAP[role.key];
+    if (responsibleMap) {
+      const newName = (currentUser?.name || currentUser?.username || 'Пользователь').trim();
+      const oldName = card[responsibleMap.nameField];
+      const oldAt = card[responsibleMap.atField];
+      card[responsibleMap.nameField] = newName;
+      card[responsibleMap.atField] = Date.now();
+      recordCardLog(card, { action: 'approval', field: responsibleMap.nameField, oldValue: oldName, newValue: card[responsibleMap.nameField] });
+      recordCardLog(card, { action: 'approval', field: responsibleMap.atField, oldValue: oldAt, newValue: card[responsibleMap.atField] });
+    }
     card.approvalThread.push({
       ts: Date.now(),
       userName: currentUser?.name || 'Пользователь',
@@ -197,6 +213,15 @@ function confirmApprovalReject() {
     const oldValue = card[role.statusField];
     card[role.statusField] = APPROVAL_STATUS_REJECTED;
     recordCardLog(card, { action: 'approval', field: role.statusField, oldValue, newValue: card[role.statusField] });
+    const responsibleMap = APPROVAL_RESPONSIBLE_MAP[role.key];
+    if (responsibleMap) {
+      const oldName = card[responsibleMap.nameField];
+      const oldAt = card[responsibleMap.atField];
+      card[responsibleMap.nameField] = '';
+      card[responsibleMap.atField] = null;
+      recordCardLog(card, { action: 'approval', field: responsibleMap.nameField, oldValue: oldName, newValue: card[responsibleMap.nameField] });
+      recordCardLog(card, { action: 'approval', field: responsibleMap.atField, oldValue: oldAt, newValue: card[responsibleMap.atField] });
+    }
     card.approvalThread.push({
       ts: Date.now(),
       userName: currentUser?.name || 'Пользователь',


### PR DESCRIPTION
## Summary
- add read-only responsible name inputs and display of approval date/time fields
- store responsible timestamps in card drafts with normalization
- auto-populate and clear responsible names and timestamps during approval actions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69524fcd1258833087b5de7f95205956)