### PR TITLE
Add provision tab and provided workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
           <a class="nav-dropdown-item" data-route="/cards/new" href="/cards/new">Создать МК</a>
           <a class="nav-dropdown-item" data-route="/cards-mki/new" href="/cards-mki/new">Создать МКИ</a>
           <a class="nav-dropdown-item" id="nav-approvals-link" data-route="/approvals" href="/approvals">Согласование</a>
+          <a class="nav-dropdown-item" data-route="/provision" href="/provision">Обеспечение</a>
           <a class="nav-dropdown-item" data-route="/directories" href="/directories">Справочники</a>
         </div>
       </div>
@@ -152,6 +153,31 @@
             </div>
           </div>
           <div id="cards-table-wrapper" class="table-wrapper"></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="provision" class="tab-section hidden">
+      <div class="card">
+        <h2>Обеспечение</h2>
+        <div id="provision-list-panel" class="cards-tab-panel">
+          <div class="flex" style="margin-bottom:8px; align-items:flex-end; flex-wrap:wrap; gap:8px;">
+            <div class="flex-col" style="flex:1 1 320px;">
+              <label for="provision-search">Поиск (QR-код, наименование, заказ, договор)</label>
+              <div class="search-with-camera">
+                <input id="provision-search" placeholder="Введите QR-код или наименование, номер заказа или договора" />
+                <button id="provision-scan-btn" class="camera-scan-btn" type="button" aria-label="Сканировать QR-код">
+                  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M4 5h2l1-2h10l1 2h2a1 1 0 011 1v12a1 1 0 01-1 1H4a1 1 0 01-1-1V6a1 1 0 011-1zm8 3a4 4 0 100 8 4 4 0 000-8zm0 2a2 2 0 110 4 2 2 0 010-4z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div class="flex-col" style="flex:0 0 auto;">
+              <button class="btn-secondary" id="provision-search-clear">Сбросить</button>
+            </div>
+          </div>
+          <div id="provision-table-wrapper" class="table-wrapper"></div>
         </div>
       </div>
     </section>
@@ -673,6 +699,22 @@
       <div class="modal-actions">
         <button type="button" class="btn-primary" id="approval-dialog-confirm">Подтвердить</button>
         <button type="button" class="btn-secondary" id="approval-dialog-cancel">Закрыть</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="provision-production-order-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="provision-production-order-title">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 id="provision-production-order-title">Заказ на производство</h3>
+      </div>
+      <div class="modal-body">
+        <p>Введите № заказа на производство</p>
+        <input id="provision-production-order-input" />
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="btn-primary" id="provision-production-order-confirm">Подтвердить</button>
+        <button type="button" class="btn-secondary" id="provision-production-order-cancel">Отмена</button>
       </div>
     </div>
   </div>

--- a/js/app.00.state.js
+++ b/js/app.00.state.js
@@ -6,6 +6,7 @@ const APPROVAL_STAGE_DRAFT = 'DRAFT';
 const APPROVAL_STAGE_ON_APPROVAL = 'ON_APPROVAL';
 const APPROVAL_STAGE_REJECTED = 'REJECTED';
 const APPROVAL_STAGE_APPROVED = 'APPROVED';
+const APPROVAL_STAGE_PROVIDED = 'PROVIDED';
 
 let cards = [];
 let ops = [];
@@ -27,6 +28,7 @@ let mobileOpsObserver = null;
 let archiveSearchTerm = '';
 let archiveStatusFilter = 'ALL';
 let approvalsSearchTerm = '';
+let provisionSearchTerm = '';
 let apiOnline = false;
 const workorderOpenCards = new Set();
 const workorderOpenGroups = new Set();
@@ -70,6 +72,7 @@ const ACCESS_TAB_CONFIG = [
   { key: 'dashboard', label: 'Дашборд' },
   { key: 'cards', label: 'МК' },
   { key: 'approvals', label: 'Согласование' },
+  { key: 'provision', label: 'Обеспечение' },
   { key: 'workorders', label: 'Трекер' },
   { key: 'archive', label: 'Архив' },
   { key: 'workspace', label: 'Рабочее место' },
@@ -518,6 +521,7 @@ function handleRoute(path, { replace = false, fromHistory = false } = {}) {
   const tabRoutes = {
     '/dashboard': 'dashboard',
     '/approvals': 'approvals',
+    '/provision': 'provision',
     '/workorders': 'workorders',
     '/archive': 'archive',
     '/workspace': 'workspace',

--- a/js/app.10.utils.js
+++ b/js/app.10.utils.js
@@ -150,7 +150,7 @@ function normalizeApprovalStatus(value, fallback = null) {
 }
 
 function isCardApprovalBlocked(card) {
-  return !card || card.approvalStage !== APPROVAL_STAGE_APPROVED;
+  return !card || card.approvalStage !== APPROVAL_STAGE_PROVIDED;
 }
 
 const APPROVAL_STATUS_FIELDS = ['approvalProductionStatus', 'approvalSKKStatus', 'approvalTechStatus'];

--- a/js/app.50.auth.js
+++ b/js/app.50.auth.js
@@ -315,19 +315,21 @@ async function bootstrapApp() {
     setupDeleteConfirmModal();
     initScanButton('cards-search', 'cards-scan-btn');
     initScanButton('approvals-search', 'approvals-scan-btn');
+    initScanButton('provision-search', 'provision-scan-btn');
     initScanButton('workorder-search', 'workorder-scan-btn');
     initScanButton('archive-search', 'archive-scan-btn');
     initScanButton('workspace-search', 'workspace-scan-btn');
     setupGroupTransferModal();
-      setupGroupExecutorModal();
-      setupAttachmentControls();
-      setupWorkspaceModal();
-      setupLogModal();
-      setupSecurityControls();
-      setupApprovalRejectModal();
-      setupApprovalApproveModal();
-      appBootstrapped = true;
-    }
+    setupGroupExecutorModal();
+    setupAttachmentControls();
+    setupWorkspaceModal();
+    setupProvisionModal();
+    setupLogModal();
+    setupSecurityControls();
+    setupApprovalRejectModal();
+    setupApprovalApproveModal();
+    appBootstrapped = true;
+  }
 
   renderEverything();
   if (window.dashboardPager && typeof window.dashboardPager.updatePages === 'function') {

--- a/js/app.70.render.cards.js
+++ b/js/app.70.render.cards.js
@@ -10,6 +10,7 @@ function getApprovalStageLabel(stage) {
   if (stage === APPROVAL_STAGE_ON_APPROVAL) return 'На согласовании';
   if (stage === APPROVAL_STAGE_REJECTED) return 'Отклонено';
   if (stage === APPROVAL_STAGE_APPROVED) return 'Согласовано';
+  if (stage === APPROVAL_STAGE_PROVIDED) return 'Обеспечено';
   return '';
 }
 
@@ -20,6 +21,108 @@ function renderApprovalStageCell(card) {
 }
 
 let approvalDialogContext = null;
+let provisionContextCardId = null;
+
+function renderProvisionTable() {
+  const wrapper = document.getElementById('provision-table-wrapper');
+  if (!wrapper) return;
+
+  const eligible = cards.filter(card => !card.archived && !card.groupId && !isGroupCard(card) && card.approvalStage === APPROVAL_STAGE_APPROVED);
+
+  if (!eligible.length) {
+    wrapper.innerHTML = '<p>Список маршрутных карт пуст.</p>';
+    return;
+  }
+
+  const termRaw = provisionSearchTerm.trim();
+  const cardMatches = (card) => {
+    return termRaw ? cardSearchScore(card, termRaw) > 0 : true;
+  };
+
+  let sortedCards = [...eligible];
+  if (termRaw) {
+    sortedCards.sort((a, b) => cardSearchScore(b, termRaw) - cardSearchScore(a, termRaw));
+  }
+
+  const filteredCards = sortedCards.filter(cardMatches);
+
+  if (!filteredCards.length) {
+    wrapper.innerHTML = '<p>Карты по запросу не найдены.</p>';
+    return;
+  }
+
+  let html = '<table><thead><tr>' +
+    '<th>Маршрутная карта № (QR)</th><th>Наименование</th><th>Статус</th><th>Этап согласования</th><th>Операций</th><th>Файлы</th><th>Действия</th>' +
+    '</tr></thead><tbody>';
+
+  filteredCards.forEach(card => {
+    const filesCount = (card.attachments || []).length;
+    const barcodeValue = getCardBarcodeValue(card);
+    const displayNumber = (card.routeCardNumber || card.orderNo || '').toString().trim() || barcodeValue;
+    html += '<tr>' +
+      '<td><button class="btn-link barcode-link" data-id="' + card.id + '" title="' + escapeHtml(barcodeValue) + '">' +
+        '<div class="mk-cell">' +
+          '<div class="mk-no">' + escapeHtml(displayNumber) + '</div>' +
+          '<div class="mk-qr">(' + escapeHtml(barcodeValue) + ')</div>' +
+        '</div>' +
+      '</button></td>' +
+      '<td>' + escapeHtml(card.name || '') + '</td>' +
+      '<td>' + renderCardStatusCell(card) + '</td>' +
+      '<td>' + renderApprovalStageCell(card) + '</td>' +
+      '<td>' + ((card.operations || []).length) + '</td>' +
+      '<td><button class="btn-small clip-btn" data-attach-card="' + card.id + '">📎 <span class="clip-count">' + filesCount + '</span></button></td>' +
+      '<td><div class="table-actions">' +
+        '<button class="btn-small" data-action="edit-card" data-id="' + card.id + '">Открыть</button>' +
+        '<button class="btn-small" data-action="print-card" data-id="' + card.id + '">Печать</button>' +
+        '<button class="btn-small" data-action="provision-card" data-id="' + card.id + '">Обеспечить</button>' +
+      '</div></td>' +
+      '</tr>';
+  });
+
+  html += '</tbody></table>';
+  wrapper.innerHTML = html;
+
+  wrapper.querySelectorAll('button[data-action="edit-card"]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const cardId = btn.getAttribute('data-id');
+      const card = cards.find(c => c.id === cardId);
+      const isMki = card && card.cardType === 'MKI';
+      const route = isMki ? '/cards-mki/new?cardId=' + encodeURIComponent(cardId) : '/cards/new?cardId=' + encodeURIComponent(cardId);
+      navigateToRoute(route);
+    });
+  });
+
+  wrapper.querySelectorAll('button[data-action="print-card"]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const card = cards.find(c => c.id === btn.getAttribute('data-id'));
+      if (!card) return;
+      printCardView(card);
+    });
+  });
+
+  wrapper.querySelectorAll('button[data-attach-card]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      openAttachmentsModal(btn.getAttribute('data-attach-card'), 'live');
+    });
+  });
+
+  wrapper.querySelectorAll('button[data-action="provision-card"]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      openProvisionModal(btn.getAttribute('data-id'));
+    });
+  });
+
+  wrapper.querySelectorAll('.barcode-link').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-id');
+      const card = cards.find(c => c.id === id);
+      if (!card) return;
+      openBarcodeModal(card);
+    });
+  });
+
+  applyReadonlyState('provision', 'provision');
+}
 
 function renderCardsTable() {
   const wrapper = document.getElementById('cards-table-wrapper');
@@ -1657,6 +1760,74 @@ function updateAttachmentCounters(cardId) {
   if (cardBtn && activeCardDraft && activeCardDraft.id === cardId) {
     cardBtn.innerHTML = '📎 Файлы (' + count + ')';
   }
+}
+
+function getProvisionOrderNumber(card) {
+  const prefix = 'Заказ на производство №:';
+  const materials = (card && card.mainMaterials ? card.mainMaterials : '').split('\n');
+  const firstLine = materials[0] ? materials[0].trim() : '';
+  if (firstLine.startsWith(prefix)) {
+    return firstLine.slice(prefix.length).trim();
+  }
+  return '';
+}
+
+function closeProvisionModal() {
+  const modal = document.getElementById('provision-production-order-modal');
+  if (!modal) return;
+  const input = document.getElementById('provision-production-order-input');
+  if (input) input.value = '';
+  modal.classList.add('hidden');
+  modal.dataset.cardId = '';
+  provisionContextCardId = null;
+}
+
+function openProvisionModal(cardId) {
+  const modal = document.getElementById('provision-production-order-modal');
+  if (!modal) return;
+  const card = cards.find(c => c.id === cardId);
+  if (!card) return;
+  ensureCardMeta(card, { skipSnapshot: true });
+  provisionContextCardId = cardId;
+  modal.dataset.cardId = cardId;
+  const input = document.getElementById('provision-production-order-input');
+  if (input) {
+    input.value = getProvisionOrderNumber(card);
+  }
+  modal.classList.remove('hidden');
+}
+
+function submitProvisionModal() {
+  const modal = document.getElementById('provision-production-order-modal');
+  if (!modal || !provisionContextCardId) return;
+  const card = cards.find(c => c.id === provisionContextCardId);
+  const input = document.getElementById('provision-production-order-input');
+  if (!card || !input) {
+    closeProvisionModal();
+    return;
+  }
+  const value = (input.value || '').trim();
+  if (!value) {
+    alert('Введите № заказа на производство');
+    return;
+  }
+  if (card.approvalStage !== APPROVAL_STAGE_APPROVED) {
+    alert('Перевод в статус «Обеспечено» доступен только из состояния «Согласовано».');
+    return;
+  }
+  const prefix = 'Заказ на производство №:';
+  const lines = (card.mainMaterials || '').split('\n');
+  if (!lines.length) lines.push('');
+  if ((lines[0] || '').trim().startsWith(prefix)) {
+    lines[0] = prefix + ' ' + value;
+  } else {
+    lines.unshift(prefix + ' ' + value);
+  }
+  card.mainMaterials = lines.join('\n');
+  card.approvalStage = APPROVAL_STAGE_PROVIDED;
+  saveData();
+  closeProvisionModal();
+  renderEverything();
 }
 
 function openGroupExecutorModal(groupId) {

--- a/js/app.81.navigation.js
+++ b/js/app.81.navigation.js
@@ -119,6 +119,8 @@ function activateTab(target, options = {}) {
     renderWorkordersTable({ collapseAll: true });
   } else if (target === 'approvals') {
     renderApprovalsTable();
+  } else if (target === 'provision') {
+    renderProvisionTable();
   } else if (target === 'archive') {
     renderArchiveTable();
   } else if (target === 'workspace') {

--- a/js/app.82.forms.js
+++ b/js/app.82.forms.js
@@ -482,6 +482,22 @@ function setupForms() {
     });
   }
 
+  const provisionSearchInput = document.getElementById('provision-search');
+  const provisionSearchClear = document.getElementById('provision-search-clear');
+  if (provisionSearchInput) {
+    provisionSearchInput.addEventListener('input', e => {
+      provisionSearchTerm = e.target.value || '';
+      renderProvisionTable();
+    });
+  }
+  if (provisionSearchClear) {
+    provisionSearchClear.addEventListener('click', () => {
+      provisionSearchTerm = '';
+      if (provisionSearchInput) provisionSearchInput.value = '';
+      renderProvisionTable();
+    });
+  }
+
   const approvalsSearchInput = document.getElementById('approvals-search');
   const approvalsSearchClear = document.getElementById('approvals-search-clear');
   if (approvalsSearchInput) {

--- a/js/app.83.render.common.js
+++ b/js/app.83.render.common.js
@@ -10,6 +10,7 @@ function renderEverything() {
   refreshCardStatuses();
   renderDashboard();
   renderCardsTable();
+  renderProvisionTable();
   renderApprovalsTable();
   renderCentersTable();
   renderOpsTable();
@@ -131,5 +132,17 @@ function setupWorkspaceModal() {
         focusWorkspaceNextInput();
       }
     });
+  });
+}
+
+function setupProvisionModal() {
+  const modal = document.getElementById('provision-production-order-modal');
+  if (!modal) return;
+  const confirmBtn = document.getElementById('provision-production-order-confirm');
+  const cancelBtn = document.getElementById('provision-production-order-cancel');
+  if (confirmBtn) confirmBtn.addEventListener('click', () => submitProvisionModal());
+  if (cancelBtn) cancelBtn.addEventListener('click', () => closeProvisionModal());
+  modal.addEventListener('click', (event) => {
+    if (event.target === modal) closeProvisionModal();
   });
 }


### PR DESCRIPTION
## Summary
- add a provision navigation item and tab mirroring the cards list for approved cards
- capture production order numbers via a modal and move cards to the new PROVIDED approval stage
- allow tracker and workspace access only to provided cards and wire up provision search/scan controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953acef8cfc8330b979e67bc5c2d27e)