### PR TITLE
Add production schedule navigation and pages

### DIFF
--- a/db.js
+++ b/db.js
@@ -14,7 +14,7 @@ function ensureDirSync(dirPath) {
 class JsonDatabase {
   constructor(filePath) {
     this.filePath = filePath;
-    this.data = { cards: [], ops: [], centers: [], areas: [], users: [], accessLevels: [] };
+    this.data = { cards: [], ops: [], centers: [], areas: [], users: [], accessLevels: [], productionSchedule: [], productionShiftTimes: [] };
     this.writeQueue = Promise.resolve();
   }
 
@@ -43,7 +43,9 @@ class JsonDatabase {
       centers: Array.isArray(payload.centers) ? payload.centers : [],
       areas: Array.isArray(payload.areas) ? payload.areas : [],
       users: Array.isArray(payload.users) ? payload.users : [],
-      accessLevels: Array.isArray(payload.accessLevels) ? payload.accessLevels : []
+      accessLevels: Array.isArray(payload.accessLevels) ? payload.accessLevels : [],
+      productionSchedule: Array.isArray(payload.productionSchedule) ? payload.productionSchedule : [],
+      productionShiftTimes: Array.isArray(payload.productionShiftTimes) ? payload.productionShiftTimes : []
     };
   }
 

--- a/index.html
+++ b/index.html
@@ -74,6 +74,15 @@
           <a class="nav-dropdown-item" data-route="/employees" href="/employees">Сотрудники</a>
         </div>
       </div>
+      <div class="nav-dropdown" id="nav-production-dropdown">
+        <button class="nav-btn nav-dropdown-toggle" type="button" aria-expanded="false" data-target="production" id="nav-production-toggle">Производство ▾</button>
+        <div class="nav-dropdown-menu" id="nav-production-menu" role="menu">
+          <a class="nav-dropdown-item" data-route="/production/schedule" href="/production/schedule">Расписание сотрудников</a>
+          <a class="nav-dropdown-item" data-route="/production/shifts" href="/production/shifts">Сменные задания</a>
+          <a class="nav-dropdown-item" data-route="/production/delayed" href="/production/delayed">Задержано</a>
+          <a class="nav-dropdown-item" data-route="/production/defects" href="/production/defects">Брак</a>
+        </div>
+      </div>
       <a class="nav-btn" data-target="archive" href="/archive">Архив</a>
       <a class="nav-btn" data-target="workspace" href="/workspace"><span class="nav-btn-multiline">Рабочее<br>место</span></a>
       <a class="nav-btn hidden" data-target="users" href="/users">Пользователи</a>
@@ -270,6 +279,33 @@
         <div id="employees-table-wrapper" class="table-wrapper"></div>
       </div>
     </section>
+
+    <section id="production-schedule" class="hidden">
+      <div class="card production-card">
+        <div class="production-toolbar">
+          <div class="production-toolbar__left">
+            <h2>Расписание сотрудников</h2>
+            <div class="production-toolbar__controls">
+              <label for="production-week-start">Неделя</label>
+              <input type="date" id="production-week-start" />
+              <button type="button" id="production-today" class="btn-secondary">Текущая дата</button>
+              <button type="button" id="production-shift-times-btn" class="btn-secondary">Время смен</button>
+            </div>
+          </div>
+          <div class="production-toolbar__actions">
+            <button type="button" id="production-reset-selection" class="btn-secondary">Сброс</button>
+          </div>
+        </div>
+        <div class="production-layout">
+          <div class="production-table-wrapper" id="production-schedule-table"></div>
+          <aside class="production-sidebar" id="production-sidebar"></aside>
+        </div>
+      </div>
+    </section>
+
+    <section id="production-shifts" class="hidden production-empty-page"></section>
+    <section id="production-delayed" class="hidden production-empty-page"></section>
+    <section id="production-defects" class="hidden production-empty-page"></section>
 
     <!-- Согласование -->
     <section id="approvals" class="hidden">
@@ -1164,6 +1200,18 @@
     </div>
   </div>
 
+  <div class="modal hidden" id="production-shift-times-modal" role="dialog" aria-modal="true" aria-labelledby="production-shift-title">
+    <div class="modal-content">
+      <button class="modal-close" type="button" aria-label="Закрыть">×</button>
+      <h3 id="production-shift-title">Время смен</h3>
+      <div class="modal-body"></div>
+      <div class="modal-actions">
+        <button type="button" class="btn-primary modal-confirm">Подтвердить</button>
+        <button type="button" class="btn-secondary modal-cancel">Отменить</button>
+      </div>
+    </div>
+  </div>
+
   </div>
 
   <script src="/barcodeScanner.js" defer></script>
@@ -1181,6 +1229,7 @@
   <script src="/js/app.72.directories.pages.js" defer></script>
   <script src="/js/app.73.receipts.js" defer></script>
   <script src="/js/app.74.approvals.js" defer></script>
+  <script src="/js/app.75.production.js" defer></script>
   <script src="/js/app.80.timer.js" defer></script>
   <script src="/js/app.81.navigation.js" defer></script>
   <script src="/js/app.82.forms.js" defer></script>

--- a/js/app.00.state.js
+++ b/js/app.00.state.js
@@ -14,6 +14,8 @@ let centers = [];
 let areas = [];
 let accessLevels = [];
 let users = [];
+let productionSchedule = [];
+let productionShiftTimes = [];
 let userPasswordCache = {};
 let workorderSearchTerm = '';
 let workorderStatusFilter = 'ALL';
@@ -74,6 +76,7 @@ const ACCESS_TAB_CONFIG = [
   { key: 'cards', label: 'МК' },
   { key: 'approvals', label: 'Согласование' },
   { key: 'provision', label: 'Обеспечение' },
+  { key: 'production', label: 'Производство' },
   { key: 'departments', label: 'Подразделения' },
   { key: 'operations', label: 'Операции' },
   { key: 'areas', label: 'Участки' },
@@ -139,6 +142,14 @@ function formatDateInputValue(value) {
 
 function getCurrentDateString() {
   return formatDateInputValue(Date.now());
+}
+
+function getDefaultProductionShiftTimes() {
+  return [
+    { shift: 1, timeFrom: '08:00', timeTo: '16:00' },
+    { shift: 2, timeFrom: '16:00', timeTo: '00:00' },
+    { shift: 3, timeFrom: '00:00', timeTo: '08:00' }
+  ];
 }
 
 function getSurnameFromUser(user) {
@@ -359,6 +370,7 @@ function getAllowedTabs() {
   document.querySelectorAll('.nav-btn').forEach(btn => {
     const target = btn.getAttribute('data-target');
     if (!target) return;
+    if (target === 'production') return;
     if (canViewTab(target)) {
       tabs.push(target);
     }
@@ -588,6 +600,21 @@ function handleRoute(path, { replace = false, fromHistory = false } = {}) {
     }
     closePageScreens();
     activateTab('approvals', { skipHistory: true, fromRestore: fromHistory });
+    pushState();
+    return;
+  }
+
+  if (basePath.startsWith('/production/')) {
+    if (!canViewTab('production')) {
+      alert('Нет прав доступа к разделу');
+      const fallback = getDefaultTab();
+      closePageScreens();
+      activateTab(fallback, { skipHistory: true, fromRestore: fromHistory });
+      pushState();
+      return;
+    }
+    closePageScreens();
+    openProductionRoute(basePath, { fromRestore: fromHistory });
     pushState();
     return;
   }

--- a/js/app.40.store.js
+++ b/js/app.40.store.js
@@ -9,7 +9,7 @@ async function saveData() {
     const res = await apiFetch(API_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cards, ops, centers, areas, users, accessLevels })
+      body: JSON.stringify({ cards, ops, centers, areas, users, accessLevels, productionSchedule, productionShiftTimes })
     });
     if (!res.ok) {
       throw new Error('Ответ сервера ' + res.status);
@@ -26,6 +26,12 @@ async function saveData() {
 function ensureDefaults() {
   if (!Array.isArray(areas)) {
     areas = [];
+  }
+  if (!Array.isArray(productionSchedule)) {
+    productionSchedule = [];
+  }
+  if (!Array.isArray(productionShiftTimes) || !productionShiftTimes.length) {
+    productionShiftTimes = getDefaultProductionShiftTimes();
   }
   if (!centers.length) {
     centers = [
@@ -84,6 +90,10 @@ async function loadData() {
     ops = Array.isArray(payload.ops) ? payload.ops : [];
     centers = Array.isArray(payload.centers) ? payload.centers : [];
     areas = Array.isArray(payload.areas) ? payload.areas : [];
+    productionSchedule = Array.isArray(payload.productionSchedule) ? payload.productionSchedule : [];
+    productionShiftTimes = Array.isArray(payload.productionShiftTimes) && payload.productionShiftTimes.length
+      ? payload.productionShiftTimes
+      : getDefaultProductionShiftTimes();
     accessLevels = Array.isArray(payload.accessLevels) ? payload.accessLevels : [];
     users = Array.isArray(payload.users)
       ? payload.users.map(user => {

--- a/js/app.50.auth.js
+++ b/js/app.50.auth.js
@@ -96,6 +96,13 @@ function applyNavigationPermissions() {
   if (approvalsSection) approvalsSection.classList.toggle('hidden', !approvalsAllowed);
   const approvalsLink = document.getElementById('nav-approvals-link');
   if (approvalsLink) approvalsLink.classList.toggle('hidden', !approvalsAllowed);
+  const productionAllowed = canViewTab('production');
+  const productionContainer = document.getElementById('nav-production-dropdown');
+  if (productionContainer) productionContainer.classList.toggle('hidden', !productionAllowed);
+  ['production-schedule', 'production-shifts', 'production-delayed', 'production-defects'].forEach(id => {
+    const section = document.getElementById(id);
+    if (section) section.classList.toggle('hidden', !productionAllowed);
+  });
 
   const isHome = window.location.pathname === '/';
   const hasHash = !!window.location.hash;
@@ -328,6 +335,7 @@ async function bootstrapApp() {
     setupSecurityControls();
     setupApprovalRejectModal();
     setupApprovalApproveModal();
+    setupProductionModule();
     appBootstrapped = true;
   }
 

--- a/js/app.75.production.js
+++ b/js/app.75.production.js
@@ -1,0 +1,697 @@
+// === ПРОИЗВОДСТВО: РАСПИСАНИЕ ===
+const PRODUCTION_WEEK_DAYS = 7;
+const PRODUCTION_WEEK_LABELS = ['вс', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'];
+
+const productionScheduleState = {
+  weekStart: null,
+  selectedShift: 1,
+  selectedCell: null,
+  selectedEmployees: [],
+  employeeFilter: '',
+  departmentId: '',
+  filterVisible: false,
+  clipboard: [],
+  selectedCellEmployeeId: null
+};
+
+function getProductionWeekStart(date = new Date()) {
+  const base = new Date(date);
+  const day = base.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  base.setHours(0, 0, 0, 0);
+  base.setDate(base.getDate() + diff);
+  return base;
+}
+
+function addDaysToDate(date, days) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function formatProductionDate(date) {
+  if (typeof date === 'string') return date;
+  const d = new Date(date);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function getProductionWeekDates() {
+  const start = productionScheduleState.weekStart || getProductionWeekStart();
+  return Array.from({ length: PRODUCTION_WEEK_DAYS }, (_, idx) => addDaysToDate(start, idx));
+}
+
+function isProductionWeekend(date) {
+  const day = new Date(date).getDay();
+  return day === 0 || day === 6;
+}
+
+function getProductionDayLabel(date) {
+  const d = new Date(date);
+  const weekday = PRODUCTION_WEEK_LABELS[d.getDay()] || '';
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const yy = String(d.getFullYear()).slice(-2);
+  return { weekday, date: `${dd}.${mm}.${yy}` };
+}
+
+function setProductionWeekStart(date) {
+  productionScheduleState.weekStart = getProductionWeekStart(date);
+  resetProductionSelection();
+  renderProductionSchedule();
+}
+
+function setProductionShift(shift) {
+  productionScheduleState.selectedShift = shift;
+  if (productionScheduleState.selectedCell) {
+    productionScheduleState.selectedCell = {
+      ...productionScheduleState.selectedCell,
+      shift
+    };
+  }
+  renderProductionSchedule();
+}
+
+function resetProductionSelection() {
+  productionScheduleState.selectedCell = null;
+  productionScheduleState.selectedEmployees = [];
+  productionScheduleState.selectedCellEmployeeId = null;
+}
+
+function getProductionAssignments(date, areaId, shift) {
+  return (productionSchedule || []).filter(rec => rec.date === date && rec.areaId === areaId && rec.shift === shift);
+}
+
+function getProductionEmployeeName(employeeId) {
+  const user = (users || []).find(u => u.id === employeeId);
+  return escapeHtml(user?.name || user?.username || 'Неизвестно');
+}
+
+function productionScheduleIsActive() {
+  const section = document.getElementById('production-schedule');
+  return section && section.classList.contains('active');
+}
+
+function setProductionSelectedCell(cell, employeeId = null) {
+  productionScheduleState.selectedCell = cell;
+  productionScheduleState.selectedCellEmployeeId = employeeId;
+}
+
+function getProductionFilterDate() {
+  if (productionScheduleState.selectedCell?.date) return productionScheduleState.selectedCell.date;
+  const weekStart = productionScheduleState.weekStart || getProductionWeekStart();
+  return formatProductionDate(weekStart);
+}
+
+function isEmployeeAvailableForShift(employeeId) {
+  const targetDate = getProductionFilterDate();
+  const shift = productionScheduleState.selectedShift;
+  return !(productionSchedule || []).some(rec => rec.employeeId === employeeId && rec.date === targetDate && rec.shift === shift);
+}
+
+function getFilteredProductionEmployees() {
+  const deptId = productionScheduleState.departmentId;
+  const search = (productionScheduleState.employeeFilter || '').toLowerCase();
+  const filtered = (users || []).filter(user => {
+    const name = (user?.name || user?.username || '').trim();
+    if (!name) return false;
+    if (deptId && user.departmentId !== deptId) return false;
+    if (!isEmployeeAvailableForShift(user.id)) return false;
+    if (search && !name.toLowerCase().includes(search)) return false;
+    return true;
+  });
+  return filtered.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+}
+
+function toggleProductionEmployeeSelection(id) {
+  const next = new Set(productionScheduleState.selectedEmployees || []);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  productionScheduleState.selectedEmployees = Array.from(next);
+  renderProductionScheduleSidebar();
+}
+
+function applyProductionEmployeeFilter(text) {
+  productionScheduleState.employeeFilter = text || '';
+  renderProductionScheduleSidebar();
+}
+
+function applyProductionDepartment(deptId) {
+  productionScheduleState.departmentId = deptId || '';
+  productionScheduleState.selectedEmployees = [];
+  renderProductionScheduleSidebar();
+}
+
+function setProductionFilterVisible(flag) {
+  productionScheduleState.filterVisible = flag;
+  renderProductionScheduleSidebar();
+}
+
+function parseProductionTime(value) {
+  if (!value || typeof value !== 'string') return null;
+  const normalized = value.trim();
+  if (!/^\d{2}:\d{2}$/.test(normalized)) return null;
+  const [hh, mm] = normalized.split(':').map(v => parseInt(v, 10));
+  if (Number.isNaN(hh) || Number.isNaN(mm)) return null;
+  return hh * 60 + mm;
+}
+
+function minutesToTimeString(minutes) {
+  const total = ((minutes % (24 * 60)) + (24 * 60)) % (24 * 60);
+  const hh = String(Math.floor(total / 60)).padStart(2, '0');
+  const mm = String(total % 60).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+function getShiftRange(shift) {
+  const ref = (productionShiftTimes || []).find(s => s.shift === shift);
+  const from = parseProductionTime(ref?.timeFrom) ?? 0;
+  let to = parseProductionTime(ref?.timeTo);
+  if (to == null) to = from;
+  if (to <= from) to += 24 * 60;
+  return { start: from, end: to };
+}
+
+function getShiftRangesForWindow(startMinutes, endMinutes) {
+  if (endMinutes <= startMinutes) endMinutes += 24 * 60;
+  return (productionShiftTimes || []).map(s => ({ shift: s.shift, range: getShiftRange(s.shift) }))
+    .map(item => {
+      const overlapStart = Math.max(item.range.start, startMinutes);
+      const overlapEnd = Math.min(item.range.end, endMinutes);
+      return overlapEnd > overlapStart ? { shift: item.shift, start: overlapStart, end: overlapEnd } : null;
+    })
+    .filter(Boolean);
+}
+
+function buildProductionAssignmentRecord({ date, areaId, shift, employeeId, timeFrom, timeTo }) {
+  return { date, areaId, shift, employeeId, timeFrom, timeTo };
+}
+
+function upsertProductionAssignment(record) {
+  const conflict = (productionSchedule || []).find(rec => rec.date === record.date && rec.shift === record.shift && rec.employeeId === record.employeeId);
+  if (conflict && conflict.areaId !== record.areaId) {
+    return { error: 'different-area' };
+  }
+  if (conflict && conflict.areaId === record.areaId) {
+    conflict.timeFrom = record.timeFrom;
+    conflict.timeTo = record.timeTo;
+    return { updated: true };
+  }
+  productionSchedule.push(record);
+  return { created: true };
+}
+
+function addEmployeesToProductionCell() {
+  const cell = productionScheduleState.selectedCell;
+  if (!cell) {
+    alert('Выберите ячейку расписания');
+    return;
+  }
+  const employeeIds = productionScheduleState.selectedEmployees || [];
+  if (!employeeIds.length) {
+    alert('Выберите сотрудников в панели справа');
+    return;
+  }
+  const fullShift = Boolean(document.getElementById('production-full-shift')?.checked);
+  const rawFrom = document.getElementById('production-time-from')?.value || null;
+  const rawTo = document.getElementById('production-time-to')?.value || null;
+  const fromMinutes = parseProductionTime(rawFrom);
+  const toMinutes = parseProductionTime(rawTo);
+
+  const created = [];
+  const skipped = [];
+
+  employeeIds.forEach(empId => {
+    const targets = [];
+    if (fullShift || fromMinutes == null || toMinutes == null) {
+      targets.push({ shift: cell.shift, start: null, end: null });
+    } else {
+      targets.push(...getShiftRangesForWindow(fromMinutes, toMinutes));
+    }
+
+    targets.forEach(target => {
+      const record = buildProductionAssignmentRecord({
+        date: cell.date,
+        areaId: cell.areaId,
+        shift: target.shift || cell.shift,
+        employeeId: empId,
+        timeFrom: target.start == null ? null : minutesToTimeString(target.start),
+        timeTo: target.end == null ? null : minutesToTimeString(target.end)
+      });
+      const result = upsertProductionAssignment(record);
+      if (result.error) {
+        skipped.push(empId);
+      } else {
+        created.push(empId);
+      }
+    });
+  });
+
+  saveData();
+  renderProductionSchedule();
+  if (skipped.length) {
+    showToast('Некоторые сотрудники уже назначены в другую ячейку этой смены');
+  } else if (created.length) {
+    showToast('Сотрудники добавлены в расписание');
+  }
+}
+
+function deleteProductionAssignments() {
+  const cell = productionScheduleState.selectedCell;
+  if (!cell) return;
+  const { date, areaId, shift } = cell;
+  const employeeId = productionScheduleState.selectedCellEmployeeId;
+  const before = productionSchedule.length;
+  productionSchedule = productionSchedule.filter(rec => {
+    if (rec.date !== date || rec.areaId !== areaId || rec.shift !== shift) return true;
+    if (employeeId && rec.employeeId !== employeeId) return true;
+    return false;
+  });
+  const removed = before !== productionSchedule.length;
+  productionScheduleState.selectedCellEmployeeId = null;
+  if (removed) {
+    saveData();
+    renderProductionSchedule();
+  }
+}
+
+function copyProductionCell() {
+  const cell = productionScheduleState.selectedCell;
+  if (!cell) return;
+  productionScheduleState.clipboard = getProductionAssignments(cell.date, cell.areaId, cell.shift).map(rec => ({ ...rec }));
+}
+
+function pasteProductionCell() {
+  const cell = productionScheduleState.selectedCell;
+  if (!cell || !(productionScheduleState.clipboard || []).length) return;
+  const copied = productionScheduleState.clipboard || [];
+  const conflicts = [];
+  copied.forEach(item => {
+    const record = { ...item, date: cell.date, areaId: cell.areaId, shift: cell.shift };
+    const result = upsertProductionAssignment(record);
+    if (result.error) conflicts.push(record.employeeId);
+  });
+  saveData();
+  renderProductionSchedule();
+  if (conflicts.length) {
+    showToast('Некоторые сотрудники уже заняты в этой смене');
+  }
+}
+
+function renderProductionWeekTable() {
+  const wrapper = document.getElementById('production-schedule-table');
+  if (!wrapper) return;
+  const dates = getProductionWeekDates();
+  const areasList = (areas || []).slice().sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+  if (!areasList.length) {
+    wrapper.innerHTML = '<p class="muted">Нет участков для отображения расписания.</p>';
+    return;
+  }
+
+  const headerCells = dates.map((date, idx) => {
+    const { weekday, date: dateLabel } = getProductionDayLabel(date);
+    const weekend = isProductionWeekend(date) ? ' weekend' : '';
+    const dateStr = formatProductionDate(date);
+    const left = idx === 0 ? '<button class="production-day-shift" data-dir="-1" type="button">←</button>' : '';
+    const right = idx === dates.length - 1 ? '<button class="production-day-shift" data-dir="1" type="button">→</button>' : '';
+    return `<th class="production-day${weekend}" data-date="${dateStr}">${left}<span class="production-day-title">${weekday}</span><span class="production-day-date">${dateLabel}</span>${right}</th>`;
+  }).join('');
+
+  const rowsHtml = areasList.map(area => {
+    const areaName = escapeHtml(area.name || 'Без названия');
+    const cells = dates.map(date => {
+      const dateStr = formatProductionDate(date);
+      const assignments = getProductionAssignments(dateStr, area.id, productionScheduleState.selectedShift);
+      const isSelected = productionScheduleState.selectedCell
+        && productionScheduleState.selectedCell.date === dateStr
+        && productionScheduleState.selectedCell.areaId === area.id
+        && productionScheduleState.selectedCell.shift === productionScheduleState.selectedShift;
+      const weekendClass = isProductionWeekend(date) ? ' weekend' : '';
+      const parts = assignments.map(rec => {
+        const name = getProductionEmployeeName(rec.employeeId);
+        const timeRange = rec.timeFrom && rec.timeTo ? ` ${rec.timeFrom}–${rec.timeTo}` : '';
+        const isActive = productionScheduleState.selectedCellEmployeeId === rec.employeeId && isSelected;
+        return `<div class="production-assignment${isActive ? ' selected' : ''}" data-employee-id="${rec.employeeId}">${name}${timeRange}</div>`;
+      }).join('');
+      const content = parts || '<div class="production-empty">—</div>';
+      const selectedClass = isSelected ? ' selected' : '';
+      return `<td class="production-cell${weekendClass}${selectedClass}" data-area-id="${area.id}" data-date="${dateStr}" data-shift="${productionScheduleState.selectedShift}">${content}</td>`;
+    }).join('');
+    return `<tr><th class="production-area">${areaName}</th>${cells}</tr>`;
+  }).join('');
+
+  wrapper.innerHTML = `<table class="production-table"><thead><tr><th class="production-area">Участок</th>${headerCells}</tr></thead><tbody>${rowsHtml}</tbody></table>`;
+}
+
+function renderProductionScheduleSidebar() {
+  const sidebar = document.getElementById('production-sidebar');
+  if (!sidebar) return;
+  const departments = (centers || []).slice().sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+  const employees = getFilteredProductionEmployees();
+  const filterInput = productionScheduleState.filterVisible
+    ? `<input type="text" id="production-employee-search" placeholder="Поиск" value="${escapeHtml(productionScheduleState.employeeFilter)}" />`
+    : '';
+
+  const shiftButtons = [1, 2, 3].map(shift => `<button type="button" class="production-shift-btn${productionScheduleState.selectedShift === shift ? ' active' : ''}" data-shift="${shift}">${shift} смена</button>`).join('');
+  const employeeItems = employees.map(emp => {
+    const name = escapeHtml(emp.name || emp.username || '');
+    const active = productionScheduleState.selectedEmployees.includes(emp.id) ? ' active' : '';
+    return `<button type="button" class="production-employee${active}" data-id="${emp.id}">${name}</button>`;
+  }).join('');
+
+  sidebar.innerHTML = `
+    <div class="production-sidebar-block">
+      <label for="production-department">Подразделение</label>
+      <select id="production-department">
+        <option value="">Все подразделения</option>
+        ${departments.map(d => `<option value="${d.id}"${productionScheduleState.departmentId === d.id ? ' selected' : ''}>${escapeHtml(d.name || '')}</option>`).join('')}
+      </select>
+    </div>
+    <div class="production-sidebar-block">
+      <div class="production-shift-group" id="production-shift-group">${shiftButtons}</div>
+    </div>
+    <div class="production-sidebar-block">
+      <div class="production-employee-filter">
+        <button type="button" id="production-toggle-filter" class="btn-tertiary">Фильтр</button>
+        ${filterInput}
+      </div>
+      <div id="production-employee-list" class="production-employee-list">${employeeItems || '<div class="muted">Нет доступных сотрудников</div>'}</div>
+    </div>
+    <div class="production-sidebar-block">
+      <label class="checkbox-inline">
+        <input type="checkbox" id="production-full-shift" ${document.getElementById('production-full-shift')?.checked !== false ? 'checked' : ''} />
+        <span>Смена</span>
+      </label>
+      <div class="production-time-row">
+        <div>
+          <label for="production-time-from">Время с</label>
+          <input type="time" id="production-time-from" ${document.getElementById('production-full-shift')?.checked !== false ? 'disabled' : ''} value="${document.getElementById('production-time-from')?.value || ''}" />
+        </div>
+        <div>
+          <label for="production-time-to">Время по</label>
+          <input type="time" id="production-time-to" ${document.getElementById('production-full-shift')?.checked !== false ? 'disabled' : ''} value="${document.getElementById('production-time-to')?.value || ''}" />
+        </div>
+      </div>
+    </div>
+    <div class="production-sidebar-actions">
+      <button type="button" class="btn-primary" id="production-add">Добавить</button>
+      <button type="button" class="btn-secondary" id="production-delete">Удалить</button>
+      <button type="button" class="btn-tertiary" id="production-reset">Сброс</button>
+    </div>
+  `;
+}
+
+function bindProductionSidebarEvents() {
+  const sidebar = document.getElementById('production-sidebar');
+  if (!sidebar || sidebar.dataset.bound === 'true') return;
+  sidebar.dataset.bound = 'true';
+
+  sidebar.addEventListener('click', (event) => {
+    const shiftBtn = event.target.closest('.production-shift-btn');
+    if (shiftBtn) {
+      const shift = parseInt(shiftBtn.getAttribute('data-shift'), 10) || 1;
+      setProductionShift(shift);
+      return;
+    }
+    const empBtn = event.target.closest('.production-employee');
+    if (empBtn) {
+      const id = empBtn.getAttribute('data-id');
+      toggleProductionEmployeeSelection(id);
+      return;
+    }
+    const filterBtn = event.target.closest('#production-toggle-filter');
+    if (filterBtn) {
+      setProductionFilterVisible(!productionScheduleState.filterVisible);
+      return;
+    }
+    const addBtn = event.target.closest('#production-add');
+    if (addBtn) {
+      addEmployeesToProductionCell();
+      return;
+    }
+    const delBtn = event.target.closest('#production-delete');
+    if (delBtn) {
+      deleteProductionAssignments();
+      return;
+    }
+    const resetBtn = event.target.closest('#production-reset');
+    if (resetBtn) {
+      productionScheduleState.selectedEmployees = [];
+      productionScheduleState.employeeFilter = '';
+      productionScheduleState.departmentId = '';
+      productionScheduleState.filterVisible = false;
+      renderProductionSchedule();
+      return;
+    }
+  });
+
+  sidebar.addEventListener('change', (event) => {
+    if (event.target.id === 'production-department') {
+      applyProductionDepartment(event.target.value);
+    }
+    if (event.target.id === 'production-full-shift') {
+      const checked = event.target.checked;
+      const fromInput = document.getElementById('production-time-from');
+      const toInput = document.getElementById('production-time-to');
+      if (fromInput) fromInput.disabled = checked;
+      if (toInput) toInput.disabled = checked;
+    }
+  });
+
+  sidebar.addEventListener('input', (event) => {
+    if (event.target.id === 'production-employee-search') {
+      applyProductionEmployeeFilter(event.target.value || '');
+    }
+  });
+}
+
+function bindProductionTableEvents() {
+  const wrapper = document.getElementById('production-schedule-table');
+  if (!wrapper || wrapper.dataset.bound === 'true') return;
+  wrapper.dataset.bound = 'true';
+
+  wrapper.addEventListener('click', (event) => {
+    const shiftBtn = event.target.closest('.production-day-shift');
+    if (shiftBtn) {
+      const dir = parseInt(shiftBtn.getAttribute('data-dir'), 10) || 0;
+      const nextStart = addDaysToDate(productionScheduleState.weekStart || getProductionWeekStart(), dir);
+      setProductionWeekStart(nextStart);
+      return;
+    }
+
+    const assignment = event.target.closest('.production-assignment');
+    const cell = event.target.closest('.production-cell');
+    if (cell) {
+      const date = cell.getAttribute('data-date');
+      const areaId = cell.getAttribute('data-area-id');
+      const shift = parseInt(cell.getAttribute('data-shift'), 10) || productionScheduleState.selectedShift;
+      const employeeId = assignment ? assignment.getAttribute('data-employee-id') : null;
+      setProductionSelectedCell({ date, areaId, shift }, employeeId);
+      renderProductionSchedule();
+      return;
+    }
+  });
+
+  wrapper.addEventListener('contextmenu', (event) => {
+    const cell = event.target.closest('.production-cell');
+    if (!cell) return;
+    event.preventDefault();
+    const date = cell.getAttribute('data-date');
+    const areaId = cell.getAttribute('data-area-id');
+    const shift = parseInt(cell.getAttribute('data-shift'), 10) || productionScheduleState.selectedShift;
+    setProductionSelectedCell({ date, areaId, shift }, null);
+    showProductionContextMenu(event.pageX, event.pageY);
+  });
+}
+
+function showProductionContextMenu(x, y) {
+  let menu = document.getElementById('production-context-menu');
+  if (!menu) {
+    menu = document.createElement('div');
+    menu.id = 'production-context-menu';
+    menu.className = 'production-context-menu';
+    menu.innerHTML = `
+      <button data-action="copy" type="button">Копировать</button>
+      <button data-action="paste" type="button">Вставить</button>
+      <button data-action="delete" type="button">Удалить</button>
+    `;
+    document.body.appendChild(menu);
+    menu.addEventListener('click', (event) => {
+      const action = event.target.getAttribute('data-action');
+      if (action === 'copy') copyProductionCell();
+      if (action === 'paste') pasteProductionCell();
+      if (action === 'delete') deleteProductionAssignments();
+      hideProductionContextMenu();
+    });
+  }
+  menu.style.left = `${x}px`;
+  menu.style.top = `${y}px`;
+  menu.classList.add('open');
+  document.addEventListener('click', hideProductionContextMenu, { once: true });
+}
+
+function hideProductionContextMenu() {
+  const menu = document.getElementById('production-context-menu');
+  if (menu) menu.classList.remove('open');
+}
+
+function handleProductionShortcuts(event) {
+  if (!productionScheduleIsActive()) return;
+  if (event.key === 'Delete') {
+    deleteProductionAssignments();
+    return;
+  }
+  if (event.key.toLowerCase() === 'c' && event.ctrlKey) {
+    copyProductionCell();
+    event.preventDefault();
+  }
+  if (event.key.toLowerCase() === 'v' && event.ctrlKey) {
+    pasteProductionCell();
+    event.preventDefault();
+  }
+}
+
+function renderProductionSchedule() {
+  productionScheduleState.weekStart = productionScheduleState.weekStart || getProductionWeekStart();
+  renderProductionWeekTable();
+  renderProductionScheduleSidebar();
+  bindProductionSidebarEvents();
+  bindProductionTableEvents();
+}
+
+function setupProductionScheduleControls() {
+  const dateInput = document.getElementById('production-week-start');
+  if (dateInput && dateInput.dataset.bound !== 'true') {
+    dateInput.dataset.bound = 'true';
+    dateInput.addEventListener('change', () => {
+      const value = dateInput.value || getCurrentDateString();
+      setProductionWeekStart(value);
+    });
+  }
+  if (dateInput) {
+    const start = productionScheduleState.weekStart || getProductionWeekStart();
+    dateInput.value = formatProductionDate(start);
+  }
+
+  const todayBtn = document.getElementById('production-today');
+  if (todayBtn && todayBtn.dataset.bound !== 'true') {
+    todayBtn.dataset.bound = 'true';
+    todayBtn.addEventListener('click', () => setProductionWeekStart(new Date()));
+  }
+
+  const resetBtn = document.getElementById('production-reset-selection');
+  if (resetBtn && resetBtn.dataset.bound !== 'true') {
+    resetBtn.dataset.bound = 'true';
+    resetBtn.addEventListener('click', () => {
+      resetProductionSelection();
+      productionScheduleState.selectedEmployees = [];
+      productionScheduleState.employeeFilter = '';
+      productionScheduleState.departmentId = '';
+      renderProductionSchedule();
+    });
+  }
+
+  const timesBtn = document.getElementById('production-shift-times-btn');
+  if (timesBtn && timesBtn.dataset.bound !== 'true') {
+    timesBtn.dataset.bound = 'true';
+    timesBtn.addEventListener('click', () => openProductionShiftTimesModal());
+  }
+
+  document.addEventListener('keydown', handleProductionShortcuts);
+}
+
+function openProductionRoute(route, { fromRestore = false } = {}) {
+  const map = {
+    '/production/schedule': 'production-schedule',
+    '/production/shifts': 'production-shifts',
+    '/production/delayed': 'production-delayed',
+    '/production/defects': 'production-defects'
+  };
+  const targetId = map[route] || 'production-schedule';
+  document.querySelectorAll('main section').forEach(sec => sec.classList.remove('active'));
+  Object.values(map).forEach(id => {
+    const section = document.getElementById(id);
+    if (section) section.classList.add('hidden');
+  });
+  document.querySelectorAll('.nav-btn').forEach(btn => btn.classList.remove('active'));
+  const target = document.getElementById(targetId);
+  if (target) {
+    target.classList.remove('hidden');
+    target.classList.add('active');
+  }
+  const navToggle = document.getElementById('nav-production-toggle');
+  if (navToggle) navToggle.classList.add('active');
+  appState = { ...appState, tab: 'production' };
+  if (targetId === 'production-schedule' && !fromRestore) {
+    renderProductionSchedule();
+  }
+}
+
+function openProductionShiftTimesModal() {
+  const modal = document.getElementById('production-shift-times-modal');
+  if (!modal) return;
+  const body = modal.querySelector('.modal-body');
+  const list = (productionShiftTimes && productionShiftTimes.length ? productionShiftTimes : getDefaultProductionShiftTimes())
+    .slice()
+    .sort((a, b) => (a.shift || 0) - (b.shift || 0));
+  body.innerHTML = list.map(item => `
+    <div class="production-shift-row">
+      <div class="production-shift-label">${item.shift} смена</div>
+      <label>С <input type="time" data-shift="${item.shift}" data-type="from" value="${escapeHtml(item.timeFrom || '')}" /></label>
+      <label>По <input type="time" data-shift="${item.shift}" data-type="to" value="${escapeHtml(item.timeTo || '')}" /></label>
+    </div>
+  `).join('');
+  modal.classList.remove('hidden');
+}
+
+function closeProductionShiftTimesModal() {
+  const modal = document.getElementById('production-shift-times-modal');
+  if (modal) modal.classList.add('hidden');
+}
+
+function saveProductionShiftTimes() {
+  const modal = document.getElementById('production-shift-times-modal');
+  if (!modal) return;
+  const inputs = modal.querySelectorAll('input[type="time"]');
+  const map = new Map();
+  inputs.forEach(input => {
+    const shift = parseInt(input.getAttribute('data-shift'), 10) || 1;
+    const type = input.getAttribute('data-type');
+    const current = map.get(shift) || { shift, timeFrom: '00:00', timeTo: '00:00' };
+    if (type === 'from') current.timeFrom = input.value || '00:00';
+    if (type === 'to') current.timeTo = input.value || '00:00';
+    map.set(shift, current);
+  });
+  productionShiftTimes = Array.from(map.values());
+  saveData();
+  closeProductionShiftTimesModal();
+  renderProductionSchedule();
+}
+
+function bindProductionShiftModal() {
+  const modal = document.getElementById('production-shift-times-modal');
+  if (!modal || modal.dataset.bound === 'true') return;
+  modal.dataset.bound = 'true';
+  const cancelBtn = modal.querySelector('.modal-cancel');
+  const confirmBtn = modal.querySelector('.modal-confirm');
+  const closeBtn = modal.querySelector('.modal-close');
+  if (cancelBtn) cancelBtn.addEventListener('click', () => closeProductionShiftTimesModal());
+  if (closeBtn) closeBtn.addEventListener('click', () => closeProductionShiftTimesModal());
+  if (confirmBtn) confirmBtn.addEventListener('click', () => saveProductionShiftTimes());
+  modal.addEventListener('click', (event) => {
+    if (event.target === modal) closeProductionShiftTimesModal();
+  });
+}
+
+function setupProductionModule() {
+  productionScheduleState.weekStart = getProductionWeekStart();
+  setupProductionScheduleControls();
+  bindProductionSidebarEvents();
+  bindProductionTableEvents();
+  bindProductionShiftModal();
+}

--- a/js/app.81.navigation.js
+++ b/js/app.81.navigation.js
@@ -7,6 +7,7 @@ function setupNavigation() {
     'Архив': 'archive',
     'Рабочееместо': 'workspace',
     'Рабочее место': 'workspace',
+    'Производство': 'production',
     'Пользователи': 'users',
     'Уровни доступа': 'accessLevels'
   };

--- a/js/app.83.render.common.js
+++ b/js/app.83.render.common.js
@@ -20,6 +20,7 @@ function renderEverything() {
   renderWorkspaceView();
   renderUsersTable();
   renderAccessLevelsTable();
+  renderProductionSchedule();
   syncReadonlyLocks();
 }
 

--- a/style.css
+++ b/style.css
@@ -3587,3 +3587,223 @@ input, textarea, select {
 .btn-small.approval-dialog-btn.btn-danger:hover {
   filter: brightness(0.95);
 }
+
+/* Производство */
+.production-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.production-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.production-toolbar__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.production-layout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 12px;
+  align-items: start;
+}
+
+.production-table-wrapper {
+  overflow: auto;
+}
+
+.production-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.production-table th,
+.production-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  vertical-align: top;
+}
+
+.production-table th.production-area {
+  width: 180px;
+  background: #f7f7f7;
+}
+
+.production-day-title {
+  display: block;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #555;
+}
+
+.production-day-date {
+  display: block;
+  font-size: 13px;
+}
+
+.production-day-shift {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 14px;
+}
+
+.production-day.weekend,
+.production-table td.weekend {
+  background: #ffecec;
+}
+
+.production-cell {
+  min-width: 140px;
+  cursor: pointer;
+  position: relative;
+}
+
+.production-cell.selected {
+  outline: 2px solid #7ac48f;
+  background: #e9f7ed;
+}
+
+.production-assignment {
+  display: inline-block;
+  background: #eef2ff;
+  padding: 4px 6px;
+  border-radius: 4px;
+  margin: 2px 4px 2px 0;
+  font-size: 13px;
+}
+
+.production-assignment.selected {
+  background: #cde9d5;
+}
+
+.production-empty {
+  color: #888;
+}
+
+.production-sidebar {
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 10px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.production-sidebar-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.production-shift-group {
+  display: flex;
+  gap: 6px;
+}
+
+.production-shift-btn {
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.production-shift-btn.active {
+  border-color: #4f46e5;
+  background: #eef2ff;
+}
+
+.production-employee-list {
+  max-height: 260px;
+  overflow: auto;
+  border: 1px solid #e5e7eb;
+  padding: 6px;
+  border-radius: 4px;
+  display: grid;
+  gap: 6px;
+}
+
+.production-employee {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.production-employee.active {
+  border-color: #10b981;
+  background: #ecfdf3;
+}
+
+.production-time-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.production-sidebar-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.production-context-menu {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  padding: 6px;
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 10;
+}
+
+.production-context-menu.open {
+  display: flex;
+}
+
+.production-context-menu button {
+  border: none;
+  background: transparent;
+  padding: 6px 8px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.production-context-menu button:hover {
+  background: #f3f4f6;
+}
+
+.production-empty-page {
+  min-height: 200px;
+}
+
+.production-shift-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.production-shift-label {
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- add Production dropdown in the header with schedule and stub pages
- introduce production schedule data models with shift times persisted in storage
- build employee schedule page with weekly grid, shift editing, and assignment controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956f4f8d98c8330af740da1b6ab9283)