### PR TITLE
Enhance production schedule UI and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,10 +286,20 @@
           <div class="production-toolbar__left">
             <h2>Расписание сотрудников</h2>
             <div class="production-toolbar__controls">
-              <label for="production-week-start">Неделя</label>
-              <input type="date" id="production-week-start" />
+              <button type="button" id="production-calendar-btn" class="btn-secondary">Календарь</button>
+              <div id="production-calendar-popover" class="production-calendar-popover">
+                <label for="production-week-start">Неделя</label>
+                <input type="date" id="production-week-start" />
+              </div>
               <button type="button" id="production-today" class="btn-secondary">Текущая дата</button>
+              <div class="production-toolbar__shifts" id="production-toolbar-shifts">
+                <button type="button" class="production-shift-btn" data-shift="1">1 смена</button>
+                <button type="button" class="production-shift-btn" data-shift="2">2 смена</button>
+                <button type="button" class="production-shift-btn" data-shift="3">3 смена</button>
+              </div>
               <button type="button" id="production-shift-times-btn" class="btn-secondary">Время смен</button>
+              <button type="button" id="production-check-mode" class="btn-tertiary">Проверка</button>
+              <button type="button" id="production-month-mode" class="btn-tertiary">Месяц</button>
             </div>
           </div>
           <div class="production-toolbar__actions">

--- a/js/app.75.production.js
+++ b/js/app.75.production.js
@@ -11,7 +11,10 @@ const productionScheduleState = {
   departmentId: '',
   filterVisible: false,
   clipboard: [],
-  selectedCellEmployeeId: null
+  selectedCellEmployeeId: null,
+  filterMode: false,
+  monthMode: false,
+  checkMode: false
 };
 
 function getProductionWeekStart(date = new Date()) {
@@ -40,7 +43,8 @@ function formatProductionDate(date) {
 
 function getProductionWeekDates() {
   const start = productionScheduleState.weekStart || getProductionWeekStart();
-  return Array.from({ length: PRODUCTION_WEEK_DAYS }, (_, idx) => addDaysToDate(start, idx));
+  const days = productionScheduleState.monthMode ? PRODUCTION_WEEK_DAYS * 4 : PRODUCTION_WEEK_DAYS;
+  return Array.from({ length: days }, (_, idx) => addDaysToDate(start, idx));
 }
 
 function isProductionWeekend(date) {
@@ -126,13 +130,8 @@ function getFilteredProductionEmployees() {
 }
 
 function toggleProductionEmployeeSelection(id) {
-  const next = new Set(productionScheduleState.selectedEmployees || []);
-  if (next.has(id)) {
-    next.delete(id);
-  } else {
-    next.add(id);
-  }
-  productionScheduleState.selectedEmployees = Array.from(next);
+  const next = productionScheduleState.selectedEmployees && productionScheduleState.selectedEmployees[0] === id ? [] : [id];
+  productionScheduleState.selectedEmployees = next;
   renderProductionScheduleSidebar();
 }
 
@@ -198,9 +197,7 @@ function upsertProductionAssignment(record) {
     return { error: 'different-area' };
   }
   if (conflict && conflict.areaId === record.areaId) {
-    conflict.timeFrom = record.timeFrom;
-    conflict.timeTo = record.timeTo;
-    return { updated: true };
+    return { duplicate: true };
   }
   productionSchedule.push(record);
   return { created: true };
@@ -283,7 +280,10 @@ function deleteProductionAssignments() {
 function copyProductionCell() {
   const cell = productionScheduleState.selectedCell;
   if (!cell) return;
-  productionScheduleState.clipboard = getProductionAssignments(cell.date, cell.areaId, cell.shift).map(rec => ({ ...rec }));
+  const selectedEmployee = productionScheduleState.selectedCellEmployeeId;
+  const source = getProductionAssignments(cell.date, cell.areaId, cell.shift);
+  const items = selectedEmployee ? source.filter(r => r.employeeId === selectedEmployee) : source;
+  productionScheduleState.clipboard = items.map(rec => ({ ...rec }));
 }
 
 function pasteProductionCell() {
@@ -294,7 +294,7 @@ function pasteProductionCell() {
   copied.forEach(item => {
     const record = { ...item, date: cell.date, areaId: cell.areaId, shift: cell.shift };
     const result = upsertProductionAssignment(record);
-    if (result.error) conflicts.push(record.employeeId);
+    if (result.error || result.duplicate) conflicts.push(record.employeeId);
   });
   saveData();
   renderProductionSchedule();
@@ -313,6 +313,22 @@ function renderProductionWeekTable() {
     return;
   }
 
+  const filterEmployeeId = productionScheduleState.filterMode ? (productionScheduleState.selectedEmployees || [])[0] || null : null;
+  const conflictKeys = new Set();
+  if (productionScheduleState.checkMode) {
+    const grouped = new Map();
+    (productionSchedule || []).forEach(rec => {
+      if (rec.shift !== productionScheduleState.selectedShift) return;
+      const key = `${rec.date}::${rec.shift}::${rec.employeeId}`;
+      const set = grouped.get(key) || new Set();
+      set.add(rec.areaId);
+      grouped.set(key, set);
+    });
+    grouped.forEach((areasSet, key) => {
+      if (areasSet.size > 1) conflictKeys.add(key);
+    });
+  }
+
   const headerCells = dates.map((date, idx) => {
     const { weekday, date: dateLabel } = getProductionDayLabel(date);
     const weekend = isProductionWeekend(date) ? ' weekend' : '';
@@ -323,29 +339,35 @@ function renderProductionWeekTable() {
   }).join('');
 
   const rowsHtml = areasList.map(area => {
+    let areaHasEmployee = false;
     const areaName = escapeHtml(area.name || 'Без названия');
     const cells = dates.map(date => {
       const dateStr = formatProductionDate(date);
       const assignments = getProductionAssignments(dateStr, area.id, productionScheduleState.selectedShift);
+      const filteredAssignments = filterEmployeeId ? assignments.filter(rec => rec.employeeId === filterEmployeeId) : assignments;
+      if (filteredAssignments.length) areaHasEmployee = true;
       const isSelected = productionScheduleState.selectedCell
         && productionScheduleState.selectedCell.date === dateStr
         && productionScheduleState.selectedCell.areaId === area.id
         && productionScheduleState.selectedCell.shift === productionScheduleState.selectedShift;
       const weekendClass = isProductionWeekend(date) ? ' weekend' : '';
-      const parts = assignments.map(rec => {
+      const parts = filteredAssignments.map(rec => {
         const name = getProductionEmployeeName(rec.employeeId);
         const timeRange = rec.timeFrom && rec.timeTo ? ` ${rec.timeFrom}–${rec.timeTo}` : '';
         const isActive = productionScheduleState.selectedCellEmployeeId === rec.employeeId && isSelected;
-        return `<div class="production-assignment${isActive ? ' selected' : ''}" data-employee-id="${rec.employeeId}">${name}${timeRange}</div>`;
+        const conflictClass = conflictKeys.has(`${rec.date}::${rec.shift}::${rec.employeeId}`) ? ' production-assignment--conflict' : '';
+        return `<div class="production-assignment${isActive ? ' selected' : ''}${conflictClass}" draggable="true" data-employee-id="${rec.employeeId}">${name}${timeRange}</div>`;
       }).join('');
       const content = parts || '<div class="production-empty">—</div>';
       const selectedClass = isSelected ? ' selected' : '';
       return `<td class="production-cell${weekendClass}${selectedClass}" data-area-id="${area.id}" data-date="${dateStr}" data-shift="${productionScheduleState.selectedShift}">${content}</td>`;
     }).join('');
+    if (filterEmployeeId && !areaHasEmployee) return '';
     return `<tr><th class="production-area">${areaName}</th>${cells}</tr>`;
   }).join('');
 
-  wrapper.innerHTML = `<table class="production-table"><thead><tr><th class="production-area">Участок</th>${headerCells}</tr></thead><tbody>${rowsHtml}</tbody></table>`;
+  const bodyContent = rowsHtml || '<tr><td colspan="100%" class="muted">Нет данных для выбранного фильтра</td></tr>';
+  wrapper.innerHTML = `<table class="production-table"><thead><tr><th class="production-area">Участок</th>${headerCells}</tr></thead><tbody>${bodyContent}</tbody></table>`;
 }
 
 function renderProductionScheduleSidebar() {
@@ -357,7 +379,6 @@ function renderProductionScheduleSidebar() {
     ? `<input type="text" id="production-employee-search" placeholder="Поиск" value="${escapeHtml(productionScheduleState.employeeFilter)}" />`
     : '';
 
-  const shiftButtons = [1, 2, 3].map(shift => `<button type="button" class="production-shift-btn${productionScheduleState.selectedShift === shift ? ' active' : ''}" data-shift="${shift}">${shift} смена</button>`).join('');
   const employeeItems = employees.map(emp => {
     const name = escapeHtml(emp.name || emp.username || '');
     const active = productionScheduleState.selectedEmployees.includes(emp.id) ? ' active' : '';
@@ -371,9 +392,6 @@ function renderProductionScheduleSidebar() {
         <option value="">Все подразделения</option>
         ${departments.map(d => `<option value="${d.id}"${productionScheduleState.departmentId === d.id ? ' selected' : ''}>${escapeHtml(d.name || '')}</option>`).join('')}
       </select>
-    </div>
-    <div class="production-sidebar-block">
-      <div class="production-shift-group" id="production-shift-group">${shiftButtons}</div>
     </div>
     <div class="production-sidebar-block">
       <div class="production-employee-filter">
@@ -401,6 +419,7 @@ function renderProductionScheduleSidebar() {
     <div class="production-sidebar-actions">
       <button type="button" class="btn-primary" id="production-add">Добавить</button>
       <button type="button" class="btn-secondary" id="production-delete">Удалить</button>
+      <button type="button" class="btn-tertiary${productionScheduleState.filterMode ? ' active' : ''}" id="production-apply-filter">Фильтр</button>
       <button type="button" class="btn-tertiary" id="production-reset">Сброс</button>
     </div>
   `;
@@ -412,12 +431,6 @@ function bindProductionSidebarEvents() {
   sidebar.dataset.bound = 'true';
 
   sidebar.addEventListener('click', (event) => {
-    const shiftBtn = event.target.closest('.production-shift-btn');
-    if (shiftBtn) {
-      const shift = parseInt(shiftBtn.getAttribute('data-shift'), 10) || 1;
-      setProductionShift(shift);
-      return;
-    }
     const empBtn = event.target.closest('.production-employee');
     if (empBtn) {
       const id = empBtn.getAttribute('data-id');
@@ -427,6 +440,17 @@ function bindProductionSidebarEvents() {
     const filterBtn = event.target.closest('#production-toggle-filter');
     if (filterBtn) {
       setProductionFilterVisible(!productionScheduleState.filterVisible);
+      return;
+    }
+    const applyFilterBtn = event.target.closest('#production-apply-filter');
+    if (applyFilterBtn) {
+      const selected = (productionScheduleState.selectedEmployees || [])[0];
+      if (!selected) {
+        alert('Выберите сотрудника для фильтрации');
+        return;
+      }
+      productionScheduleState.filterMode = !productionScheduleState.filterMode;
+      renderProductionSchedule();
       return;
     }
     const addBtn = event.target.closest('#production-add');
@@ -444,6 +468,7 @@ function bindProductionSidebarEvents() {
       productionScheduleState.selectedEmployees = [];
       productionScheduleState.employeeFilter = '';
       productionScheduleState.departmentId = '';
+      productionScheduleState.filterMode = false;
       productionScheduleState.filterVisible = false;
       renderProductionSchedule();
       return;
@@ -507,6 +532,67 @@ function bindProductionTableEvents() {
     setProductionSelectedCell({ date, areaId, shift }, null);
     showProductionContextMenu(event.pageX, event.pageY);
   });
+
+  wrapper.addEventListener('dragstart', (event) => {
+    const assignment = event.target.closest('.production-assignment');
+    const cell = event.target.closest('.production-cell');
+    if (!assignment || !cell) return;
+    const date = cell.getAttribute('data-date');
+    const areaId = cell.getAttribute('data-area-id');
+    const shift = parseInt(cell.getAttribute('data-shift'), 10) || productionScheduleState.selectedShift;
+    const record = (getProductionAssignments(date, areaId, shift) || []).find(r => r.employeeId === assignment.getAttribute('data-employee-id')) || {};
+    const payload = {
+      employeeId: assignment.getAttribute('data-employee-id'),
+      date,
+      areaId,
+      shift,
+      timeFrom: record.timeFrom || null,
+      timeTo: record.timeTo || null
+    };
+    event.dataTransfer.setData('application/json', JSON.stringify(payload));
+  });
+
+  wrapper.addEventListener('dragover', (event) => {
+    if (event.target.closest('.production-cell')) {
+      event.preventDefault();
+    }
+  });
+
+  wrapper.addEventListener('drop', (event) => {
+    const cell = event.target.closest('.production-cell');
+    if (!cell) return;
+    event.preventDefault();
+    const raw = event.dataTransfer.getData('application/json');
+    if (!raw) return;
+    try {
+      const payload = JSON.parse(raw);
+      const target = {
+        date: cell.getAttribute('data-date'),
+        areaId: cell.getAttribute('data-area-id'),
+        shift: parseInt(cell.getAttribute('data-shift'), 10) || productionScheduleState.selectedShift
+      };
+      if (payload.date === target.date && payload.areaId === target.areaId && payload.shift === target.shift) return;
+      const originalRecord = (productionSchedule || []).find(rec => rec.date === payload.date && rec.areaId === payload.areaId && rec.shift === payload.shift && rec.employeeId === payload.employeeId);
+      productionSchedule = productionSchedule.filter(rec => !(rec.date === payload.date && rec.areaId === payload.areaId && rec.shift === payload.shift && rec.employeeId === payload.employeeId));
+      const record = buildProductionAssignmentRecord({
+        date: target.date,
+        areaId: target.areaId,
+        shift: target.shift,
+        employeeId: payload.employeeId,
+        timeFrom: payload.timeFrom || null,
+        timeTo: payload.timeTo || null
+      });
+      const result = upsertProductionAssignment(record);
+      if (result.error || result.duplicate) {
+        if (originalRecord) productionSchedule.push(originalRecord);
+      } else {
+        saveData();
+        renderProductionSchedule();
+      }
+    } catch (err) {
+      console.warn('Drop failed', err);
+    }
+  });
 }
 
 function showProductionContextMenu(x, y) {
@@ -562,6 +648,14 @@ function renderProductionSchedule() {
   renderProductionScheduleSidebar();
   bindProductionSidebarEvents();
   bindProductionTableEvents();
+  const checkBtn = document.getElementById('production-check-mode');
+  if (checkBtn) checkBtn.classList.toggle('active', productionScheduleState.checkMode);
+  const monthBtn = document.getElementById('production-month-mode');
+  if (monthBtn) monthBtn.classList.toggle('active', productionScheduleState.monthMode);
+  document.querySelectorAll('#production-toolbar-shifts .production-shift-btn').forEach(btn => {
+    const value = parseInt(btn.getAttribute('data-shift'), 10) || 1;
+    btn.classList.toggle('active', value === productionScheduleState.selectedShift);
+  });
 }
 
 function setupProductionScheduleControls() {
@@ -578,6 +672,23 @@ function setupProductionScheduleControls() {
     dateInput.value = formatProductionDate(start);
   }
 
+  const calendarBtn = document.getElementById('production-calendar-btn');
+  const calendarPopover = document.getElementById('production-calendar-popover');
+  if (calendarBtn && calendarBtn.dataset.bound !== 'true') {
+    calendarBtn.dataset.bound = 'true';
+    calendarBtn.addEventListener('click', () => {
+      if (calendarPopover) calendarPopover.classList.toggle('open');
+    });
+  }
+  if (calendarPopover && calendarPopover.dataset.bound !== 'true') {
+    calendarPopover.dataset.bound = 'true';
+    document.addEventListener('click', (event) => {
+      if (!calendarPopover.contains(event.target) && event.target !== calendarBtn) {
+        calendarPopover.classList.remove('open');
+      }
+    });
+  }
+
   const todayBtn = document.getElementById('production-today');
   if (todayBtn && todayBtn.dataset.bound !== 'true') {
     todayBtn.dataset.bound = 'true';
@@ -592,6 +703,7 @@ function setupProductionScheduleControls() {
       productionScheduleState.selectedEmployees = [];
       productionScheduleState.employeeFilter = '';
       productionScheduleState.departmentId = '';
+      productionScheduleState.filterMode = false;
       renderProductionSchedule();
     });
   }
@@ -602,7 +714,42 @@ function setupProductionScheduleControls() {
     timesBtn.addEventListener('click', () => openProductionShiftTimesModal());
   }
 
+  const shiftToolbar = document.getElementById('production-toolbar-shifts');
+  if (shiftToolbar && shiftToolbar.dataset.bound !== 'true') {
+    shiftToolbar.dataset.bound = 'true';
+    shiftToolbar.addEventListener('click', (event) => {
+      const shiftBtn = event.target.closest('.production-shift-btn');
+      if (!shiftBtn) return;
+      const shift = parseInt(shiftBtn.getAttribute('data-shift'), 10) || 1;
+      setProductionShift(shift);
+    });
+  }
+
   document.addEventListener('keydown', handleProductionShortcuts);
+
+  const checkBtn = document.getElementById('production-check-mode');
+  if (checkBtn && checkBtn.dataset.bound !== 'true') {
+    checkBtn.dataset.bound = 'true';
+    checkBtn.addEventListener('click', () => {
+      productionScheduleState.checkMode = !productionScheduleState.checkMode;
+      renderProductionSchedule();
+    });
+  }
+
+  const monthBtn = document.getElementById('production-month-mode');
+  if (monthBtn && monthBtn.dataset.bound !== 'true') {
+    monthBtn.dataset.bound = 'true';
+    monthBtn.addEventListener('click', () => {
+      productionScheduleState.monthMode = !productionScheduleState.monthMode;
+      if (productionScheduleState.monthMode) {
+        const base = productionScheduleState.weekStart || getProductionWeekStart();
+        const start = new Date(base);
+        start.setDate(1);
+        productionScheduleState.weekStart = getProductionWeekStart(start);
+      }
+      renderProductionSchedule();
+    });
+  }
 }
 
 function openProductionRoute(route, { fromRestore = false } = {}) {

--- a/style.css
+++ b/style.css
@@ -3608,6 +3608,29 @@ input, textarea, select {
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  position: relative;
+}
+
+.production-toolbar__shifts {
+  display: flex;
+  gap: 6px;
+}
+
+.production-calendar-popover {
+  position: absolute;
+  display: none;
+  padding: 6px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 5;
+}
+
+.production-calendar-popover.open {
+  display: block;
 }
 
 .production-layout {
@@ -3687,6 +3710,10 @@ input, textarea, select {
   background: #cde9d5;
 }
 
+.production-assignment--conflict {
+  border: 1px solid #ef4444;
+}
+
 .production-empty {
   color: #888;
 }
@@ -3761,6 +3788,13 @@ input, textarea, select {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.production-sidebar-actions .btn-tertiary.active,
+.production-toolbar .btn-tertiary.active,
+.production-toolbar .btn-secondary.active {
+  background: #eef2ff;
+  border-color: #4f46e5;
 }
 
 .production-context-menu {


### PR DESCRIPTION
## Summary
- add production header controls for calendar selection, shift toggles, and check/month modes
- enforce schedule rules for copying, pasting, filtering, and drag-and-drop with conflict protection
- style the new production controls and conflict indicators

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69578da01cec8330a87bed173f359c76)