### PR TITLE
Add row reorder editor for production schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,6 +289,9 @@
               <input type="date" id="production-week-start" aria-label="Неделя" />
               <button type="button" id="production-today" class="btn-secondary">Текущая дата</button>
               <button type="button" id="production-shift-times-btn" class="btn-secondary">Время смен</button>
+              <button id="production-editor-toggle" class="btn btn-small">
+                Редактор
+              </button>
               <div class="production-shift-group" id="production-shift-controls"></div>
             </div>
           </div>

--- a/style.css
+++ b/style.css
@@ -3874,3 +3874,33 @@ input, textarea, select {
 .production-shift-label {
   font-weight: 600;
 }
+
+.area-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.area-reorder {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.area-reorder button {
+  width: 20px;
+  height: 18px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.area-reorder button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+#production-editor-toggle.active {
+  background-color: #2563eb;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add a toggleable editor mode for production schedule rows with per-user ordering keys
- persist area ordering in localStorage and render tables according to saved order
- add UI controls and styles for moving areas up or down

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695a401bf2748330ab7f74d3339219a2)