### PR TITLE
Normalize user identifiers and employees handling

### DIFF
--- a/db.js
+++ b/db.js
@@ -11,6 +11,12 @@ function ensureDirSync(dirPath) {
   }
 }
 
+function normalizeUser(user) {
+  const id = String(user?.id || '').trim();
+  const departmentId = user?.departmentId == null ? null : String(user.departmentId).trim();
+  return { ...user, id, departmentId };
+}
+
 class JsonDatabase {
   constructor(filePath) {
     this.filePath = filePath;
@@ -42,7 +48,7 @@ class JsonDatabase {
       ops: Array.isArray(payload.ops) ? payload.ops : [],
       centers: Array.isArray(payload.centers) ? payload.centers : [],
       areas: Array.isArray(payload.areas) ? payload.areas : [],
-      users: Array.isArray(payload.users) ? payload.users : [],
+      users: Array.isArray(payload.users) ? payload.users.map(normalizeUser) : [],
       accessLevels: Array.isArray(payload.accessLevels) ? payload.accessLevels : [],
       productionSchedule: Array.isArray(payload.productionSchedule) ? payload.productionSchedule : [],
       productionShiftTimes: Array.isArray(payload.productionShiftTimes) ? payload.productionShiftTimes : []

--- a/index.html
+++ b/index.html
@@ -289,6 +289,9 @@
               <input type="date" id="production-week-start" aria-label="Неделя" />
               <button type="button" id="production-today" class="btn-secondary">Текущая дата</button>
               <button type="button" id="production-shift-times-btn" class="btn-secondary">Время смен</button>
+              <button id="production-editor-toggle" class="btn btn-small">
+                Редактор
+              </button>
               <div class="production-shift-group" id="production-shift-controls"></div>
             </div>
           </div>

--- a/js/app.40.store.js
+++ b/js/app.40.store.js
@@ -96,11 +96,11 @@ async function loadData() {
       : getDefaultProductionShiftTimes();
     accessLevels = Array.isArray(payload.accessLevels) ? payload.accessLevels : [];
     users = Array.isArray(payload.users)
-      ? payload.users.map(user => {
-        const rawDept = user.departmentId;
-        const normalizedDept = rawDept == null ? null : String(rawDept).trim();
-        return { ...user, departmentId: normalizedDept || null };
-      })
+      ? payload.users.map(user => ({
+        ...user,
+        id: String(user.id).trim(),
+        departmentId: user.departmentId == null ? null : String(user.departmentId).trim()
+      }))
       : [];
     apiOnline = true;
     setConnectionStatus('', 'info');
@@ -162,7 +162,13 @@ async function loadSecurityData() {
     ]);
     if (usersRes.ok) {
       const payload = await usersRes.json();
-      users = Array.isArray(payload.users) ? payload.users : [];
+      users = Array.isArray(payload.users)
+        ? payload.users.map(user => ({
+          ...user,
+          id: String(user.id).trim(),
+          departmentId: user.departmentId == null ? null : String(user.departmentId).trim()
+        }))
+        : [];
       users.forEach(u => {
         const cached = resolveUserPassword(u);
         if (cached) u.password = cached;

--- a/js/app.72.directories.pages.js
+++ b/js/app.72.directories.pages.js
@@ -388,7 +388,8 @@ function renderEmployeesPage() {
   if (!wrapper) return;
   const filteredUsers = (users || []).filter(user => {
     const name = (user?.name || user?.username || '').trim();
-    return name && name.toLowerCase() !== 'abyss';
+    const login = (user?.login || '').trim();
+    return name && name.toLowerCase() !== 'abyss' && login !== 'Abyss' && name !== 'Abyss';
   });
   if (!filteredUsers.length) {
     wrapper.innerHTML = '<p>Сотрудники не найдены.</p>';
@@ -409,7 +410,7 @@ function renderEmployeesPage() {
 
   wrapper.querySelectorAll('select.employee-department-select').forEach(select => {
     const userId = select.getAttribute('data-id');
-    const user = users.find(u => u.id === userId);
+    const user = users.find(u => String(u.id) === String(userId));
     if (!user) return;
     select.value = user.departmentId || '';
     select.addEventListener('change', () => {

--- a/server.js
+++ b/server.js
@@ -701,13 +701,26 @@ function normalizeProductionSchedule(raw, shiftTimes = []) {
   return deduped.filter(item => validShifts.size === 0 || validShifts.has(item.shift));
 }
 
+function normalizeUser(user) {
+  const id = String(user?.id || '').trim();
+  const departmentId = normalizeDepartmentId(user?.departmentId);
+  const login = trimToString(user?.login);
+  const name = trimToString(user?.name || user?.username);
+  const isAbyss = login === 'Abyss' || name === 'Abyss';
+  return {
+    ...user,
+    id,
+    departmentId: isAbyss ? null : departmentId
+  };
+}
+
 function normalizeData(payload) {
   const safe = {
     cards: Array.isArray(payload.cards) ? payload.cards.map(normalizeCard) : [],
     ops: Array.isArray(payload.ops) ? payload.ops : [],
     centers: Array.isArray(payload.centers) ? payload.centers : [],
     areas: Array.isArray(payload.areas) ? payload.areas : [],
-    users: Array.isArray(payload.users) ? payload.users.map(user => ({ ...user, departmentId: normalizeDepartmentId(user.departmentId) })) : [],
+    users: Array.isArray(payload.users) ? payload.users.map(normalizeUser) : [],
     accessLevels: Array.isArray(payload.accessLevels)
       ? payload.accessLevels.map(level => ({
         id: level.id || genId('lvl'),

--- a/style.css
+++ b/style.css
@@ -3874,3 +3874,33 @@ input, textarea, select {
 .production-shift-label {
   font-weight: 600;
 }
+
+.area-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.area-reorder {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.area-reorder button {
+  width: 20px;
+  height: 18px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.area-reorder button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+#production-editor-toggle.active {
+  background-color: #2563eb;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- normalize user identifiers and department ids as strings across frontend and backend
- filter out Abyss from employees management and ensure department changes target matching string ids
- enforce server-side Abyss department nulling while persisting normalized user records

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695a401bf2748330ab7f74d3339219a2)