### PR TITLE
Add UI filter toggle for production schedule table

### DIFF
--- a/style.css
+++ b/style.css
@@ -3830,6 +3830,16 @@ input, textarea, select {
   flex-wrap: wrap;
 }
 
+/* Production schedule: визуальный фильтр */
+.production-assignment.filtered-out {
+  display: none;
+}
+
+#production-filter.active {
+  filter: brightness(0.95);
+  box-shadow: inset 0 0 0 2px rgba(0,0,0,0.12);
+}
+
 .production-context-menu {
   position: absolute;
   background: #fff;


### PR DESCRIPTION
## Summary
- add filter toggle state to production schedule and highlight active filter button
- render filter control in sidebar and flip visibility based on selected employees
- visually hide non-selected assignments while preserving underlying data

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695a531ba36c8330b427b70b4c51bf76)