### PR TITLE
Highlight today's production schedule column

### DIFF
--- a/js/app.75.production.js
+++ b/js/app.75.production.js
@@ -382,12 +382,21 @@ function pasteProductionCell() {
   }
 }
 
+function getTodayDateStrLocal() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
 function renderProductionWeekTable() {
   const wrapper = document.getElementById('production-schedule-table');
   if (!wrapper) return;
   const dates = getProductionWeekDates();
   const { areasList, order: areasOrder } = getProductionAreasWithOrder();
   const orderMap = new Map(areasOrder.map((id, idx) => [id, idx]));
+  const todayDateStr = getTodayDateStrLocal();
   if (!areasList.length) {
     wrapper.innerHTML = '<p class="muted">Нет участков для отображения расписания.</p>';
     return;
@@ -397,10 +406,12 @@ function renderProductionWeekTable() {
     const { weekday, date: dateLabel } = getProductionDayLabel(date);
     const weekend = isProductionWeekend(date) ? ' weekend' : '';
     const dateStr = formatProductionDate(date);
+    const isToday = dateStr === todayDateStr;
+    const thClass = `production-day${isToday ? ' production-today' : ''}${weekend}`;
     const left = idx === 0 ? '<button class="production-day-shift" data-dir="-1" type="button">←</button>' : '';
     const right = idx === dates.length - 1 ? '<button class="production-day-shift" data-dir="1" type="button">→</button>' : '';
     return `
-      <th class="production-day${weekend}" data-date="${dateStr}">
+      <th class="${thClass}" data-date="${dateStr}">
         <div class="production-day-header">
           ${left}
           <div class="production-day-info">
@@ -433,6 +444,8 @@ function renderProductionWeekTable() {
         && productionScheduleState.selectedCell.areaId === area.id
         && productionScheduleState.selectedCell.shift === productionScheduleState.selectedShift;
       const weekendClass = isProductionWeekend(date) ? ' weekend' : '';
+      const isToday = dateStr === todayDateStr;
+      const todayClass = isToday ? ' production-today' : '';
       const filterOn = productionScheduleState.tableFilterEnabled && productionScheduleState.selectedEmployees.length > 0;
 
       let visibleCount = 0;
@@ -457,7 +470,7 @@ function renderProductionWeekTable() {
         content = parts;
       }
       const selectedClass = isSelected ? ' selected' : '';
-      return `<td class="production-cell${weekendClass}${selectedClass}" data-area-id="${area.id}" data-date="${dateStr}" data-shift="${productionScheduleState.selectedShift}">${content}</td>`;
+      return `<td class="production-cell${weekendClass}${todayClass}${selectedClass}" data-area-id="${area.id}" data-date="${dateStr}" data-shift="${productionScheduleState.selectedShift}">${content}</td>`;
     }).join('');
     return `<tr><th class="production-area">${areaCell}</th>${cells}</tr>`;
   }).join('');

--- a/style.css
+++ b/style.css
@@ -3699,6 +3699,14 @@ input, textarea, select {
   background: #ffecec;
 }
 
+.production-today {
+  background-color: #f2edff;
+}
+
+th.production-day.production-today {
+  font-weight: 600;
+}
+
 .production-cell {
   min-width: 140px;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- highlight the current date column in the production schedule header and cells with a new production-today class
- add a helper to compute today’s local date string for table rendering
- style the highlighted column with a light purple background and bolder header text

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695a82ec38488330805b7ec396bcde23)