### PR TITLE
Add day selection and clipboard handling to production schedule

### DIFF
--- a/style.css
+++ b/style.css
@@ -3727,6 +3727,13 @@ th.production-day.production-today {
   background: #e9f7ed;
 }
 
+/* Selected day column (green outline like selected cell) */
+.production-table th.production-day.day-selected,
+.production-table td.production-cell.day-selected {
+  outline: 2px solid #7ac48f;
+  outline-offset: -2px;
+}
+
 .production-assignment {
   display: inline-block;
   background: #eef2ff;


### PR DESCRIPTION
## Summary
- allow selecting production day headers via click and context menu
- support typed clipboard for copying/pasting entire days or single cells
- highlight selected day columns with green outline styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695a9d4c34f883308bb365db9bca26c2)