### PR TITLE
Fix employee deletion selection in production schedule

### DIFF
--- a/js/app.75.production.js
+++ b/js/app.75.production.js
@@ -812,7 +812,9 @@ function bindProductionTableEvents() {
     const date = cell.getAttribute('data-date');
     const areaId = cell.getAttribute('data-area-id');
     const shift = parseInt(cell.getAttribute('data-shift'), 10) || productionScheduleState.selectedShift;
-    setProductionSelectedCell({ date, areaId, shift }, null);
+    const assignment = event.target.closest('.production-assignment');
+    const employeeId = assignment ? assignment.getAttribute('data-employee-id') : null;
+    setProductionSelectedCell({ date, areaId, shift }, employeeId);
     showProductionContextMenu(event.pageX, event.pageY);
   });
 }


### PR DESCRIPTION
## Summary
- preserve selected employee when opening context menu on schedule cells
- ensure delete actions target the right assignment instead of clearing entire cell

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d02d504ec83309d6c12583cd98464)